### PR TITLE
logging: workaround for TRACE macro conflict

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -15,7 +15,7 @@ http_archive(
     workspace_file_content = 'workspace(name = "nlohmann_json")',
 )
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+# fmt library, which is a dependency of spdlog
 git_repository(
     name = "fmt",
     branch = "master",

--- a/libraries/logging/backend.hpp
+++ b/libraries/logging/backend.hpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <variant>
 #include <google/protobuf/util/time_util.h>
-#define SPDLOG_ACTIVE_LEVEL TRACE
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include "spdlog/spdlog.h"  // spdlog API: https://github.com/gabime/spdlog
 #include <opencv2/opencv.hpp> // apparently we cannot avoid this with templates
 

--- a/libraries/logging/levels.hpp
+++ b/libraries/logging/levels.hpp
@@ -1,6 +1,12 @@
 #ifndef _MRA_LIBRARIES_LOGGING_LEVELS_HPP
 #define _MRA_LIBRARIES_LOGGING_LEVELS_HPP
 
+// workaround for TRACE macro that may have been defined already
+#ifdef TRACE
+#undef TRACE
+#endif
+
+
 namespace MRA::Logging
 {
 


### PR DESCRIPTION
When upgrading the MRA dependency at Falcons/code, I ran into a conflict.

Falcons `tracing.hpp` defines a `TRACE` macro (similar to `MRA_TRACE`, which was inspired by it).

Most of the falcons code files include `tracing.hpp`, most often directly, sometimes indirectly.

MRA defines `TRACE` as enum value in `logging/levels.hpp`.
