### PR TITLE
Gtest present check added to root CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,18 @@ set(CMAKE_CXX_FLAGS "-std=c++17 -Wall -Werror -Wno-address -Wno-reorder -Wno-arr
 # install on Ubuntu: sudo apt-get install protobuf-compiler
 find_package(Protobuf REQUIRED)
 if(NOT PROTOBUF_FOUND)
-message(FATAL_ERROR, "Protobuf could not be find. Install protobuf (e.g. sudo apt-get install protobuf-compiler)")
+message(FATAL_ERROR "Protobuf could not be find by cmake. Install protobuf (e.g. sudo apt-get install protobuf-compiler)")
 endif(NOT PROTOBUF_FOUND)
 find_library(PROTOBUF_LIBRARY protobuf)
 
 # dependency: opencv
 include_directories(/usr/include/opencv4)
+
+# dependency gtest 
+find_package(GTest)
+if(NOT GTEST_FOUND)
+message(FATAL_ERROR "GTest could not be find by cmake. Install Gtest (e.g. sudo apt-get install libgtest-dev)")
+endif()
 
 # dependency: json
 include(FetchContent)


### PR DESCRIPTION
check if GTest package is installed.
If not an fatal error is generated with clear message what is missing.

+ Fixed fatal error check for protobuf