### PR TITLE
Bugfix/closeball

### DIFF
--- a/components/falcons/getball_fetch/test.cpp
+++ b/components/falcons/getball_fetch/test.cpp
@@ -114,6 +114,32 @@ TEST(FalconsGetballFetchTest, getStationaryBallCloseToRobotOnRight)
     EXPECT_FLOAT_EQ(output.target().position().y(), -1.5);
 }
 
+// Verify target position in case of stationary ball close to robot at right side and in front of robot
+TEST(FalconsGetballFetchTest, getStationaryBallCloseToRobotInFront)
+{
+    // Arrange
+    auto m = FalconsGetballFetch::FalconsGetballFetch();
+    auto input = FalconsGetballFetch::Input();
+    auto output = FalconsGetballFetch::Output();
+    input.mutable_worldstate()->mutable_robot()->set_active(true);
+    input.mutable_worldstate()->mutable_robot()->mutable_position()->set_x(0.5);
+    input.mutable_worldstate()->mutable_robot()->mutable_position()->set_y(-0.5);
+    input.mutable_worldstate()->mutable_robot()->mutable_position()->set_rz(M_PI * 0.25); // face towards ball at (0,0)
+    input.mutable_worldstate()->mutable_ball()->mutable_position()->set_x(0.0);
+    input.mutable_worldstate()->mutable_ball()->mutable_position()->set_y(0.0);
+
+    // Act
+    int error_value = m.tick(input, output);
+
+    // Assert
+    EXPECT_EQ(error_value, 0);
+    EXPECT_EQ(output.actionresult(), MRA::Datatypes::RUNNING);
+    // robot should just drive forward to ball
+    EXPECT_FLOAT_EQ(output.target().position().x(), 0.0);
+    EXPECT_FLOAT_EQ(output.target().position().y(), 0.0);
+    EXPECT_FLOAT_EQ(output.target().position().rz(), M_PI * 0.25);
+}
+
 // Verify target position in case of stationary ball far from robot
 TEST(FalconsGetballFetchTest, getStationaryBallFarFromRobot)
 {

--- a/components/falcons/getball_fetch/tick.cpp
+++ b/components/falcons/getball_fetch/tick.cpp
@@ -80,7 +80,7 @@ int FalconsGetballFetch::FalconsGetballFetch::tick
             target.faceAwayFrom(robot_position);
 
             // get shortest angle between current robot angle and target angle.
-            auto angle_to_rotate = MRA::Geometry::min_angle(robot_position.y, target.rz);
+            auto angle_to_rotate = MRA::Geometry::min_angle(robot_position.rz, target.rz);
 
             if (fabs(angle_to_rotate) > MRA::Geometry::deg_to_rad(params.rotationonlyangle())
                 and (robot_position-ball_position).size() < params.rotationonlydistance()) {


### PR DESCRIPTION
When testing on robot, it would sometimes refuse to get a closeby ball.
Added test case, fixed the bug.
This time I tested on Falcons Simulator, maybe I should not have skipped that last time...

Actually, a simulator around MotionPlanning, PathPlanning and VelocityControl (later adding Strategy) would be a nice addition to MRA?
If only someone would write an interface proposal ;).