### PR TITLE
Traceviewer

### DIFF
--- a/MRA-build.py
+++ b/MRA-build.py
@@ -77,7 +77,7 @@ class Builder():
         cmd = 'rm -rf /tmp/testsuite_mra_logging'
         self.run_cmd(cmd)
         # set test configuration (maybe we need some scripting for this ... ?)
-        cmd = 'echo \'{"folder":"/tmp/testsuite_mra_logging","filename":"\u003cmaincomponent\u003e_\u003cpid\u003e.log","general":{"component":"MRA","level":"TRACE","enabled":true,"dumpTicks":true,"maxLineSize":1000,"maxFileSizeMB":10,"pattern":"[%Y-%m-%dT%H:%M:%S.%f] [%P/%t/%k] [%^%l%$] [%s:%#,%!] %v"}}\' > ' + TESTSUITE_SHM_FILE
+        cmd = 'echo \'{"folder":"/tmp/testsuite_mra_logging","filename":"\u003cmaincomponent\u003e_\u003cpid\u003e.spdlog","general":{"component":"MRA","level":"TRACE","enabled":true,"dumpTicks":true,"maxLineSize":1000,"maxFileSizeMB":10,"pattern":"[%Y-%m-%dT%H:%M:%S.%f] [%P/%t/%k] [%^%l%$] [%s:%#,%!] %v"}}\' > ' + TESTSUITE_SHM_FILE
         self.run_cmd(cmd)
     def run_cmd(self, cmd: str) -> None:
         extra_opts = {}

--- a/MRA-traceview.py
+++ b/MRA-traceview.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+'''
+View MRA tracing files.
+'''
+
+EXAMPLE_TXT = '''Example:
+* after running the test suite, the following files may appear
+    TODO
+* running this script will automatically open and visualize them:
+    MRA-traceview.py /tmp/testsuite_mra_logging
+'''
+
+# python modules
+import os, sys
+import subprocess
+import glob
+
+# get repo extendedlogging
+try:
+    import ttvlib
+except ImportError:
+    # try environment variable
+    epath = os.getenv('PATH_TO_EXTENDEDLOGGING')
+    if not epath:
+        # try bazel dependency
+        epath = os.path.join(subprocess.getoutput('bazel info output_base'), 'external', 'extendedlogging')
+    if not os.path.isdir(epath):
+        raise Exception('failed to find repo extendedlogging')
+    sys.path.append(epath)
+    import ttvlib
+
+# where to look for the data
+DEFAULT_FOLDER = '/tmp/mra_logging'
+
+
+
+def parse_args():
+    # modify cli
+    parser = ttvlib.ttviewer.make_parser(__doc__, EXAMPLE_TXT)
+    parser.add_argument('folder', help='folder to analyze', nargs='?', default=DEFAULT_FOLDER)
+    return parser.parse_args()
+
+
+def determine_filenames(folder):
+    fn = glob.glob(os.path.join(folder, '*'))
+    fn = [f for f in fn if os.path.isfile(f)]
+    return fn
+
+
+def pid_tid_handler(filename, jsondata):
+    for j in jsondata:
+        j['pid'] = os.path.basename(filename)
+
+
+def main(**kwargs):
+    # determine MRA tracing/logging files
+    filenames = determine_filenames(kwargs.get('folder'))
+    del kwargs['folder']
+    # feed filenames and run the viewer
+    kwargs['filenames'] = filenames
+    kwargs['pid_tid_handler'] = pid_tid_handler
+    ttvlib.ttviewer.run(**kwargs)
+
+
+if __name__ == '__main__':
+    # parse arguments, reuse ttviewer commandline interface
+    kwargs = vars(parse_args())
+    main(**kwargs)
+

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -109,3 +109,12 @@ git_repository(
     commit = "b2e7687baf5773cfafcea12d6928991605b14b0d", # 2023-08-11
     remote = "https://github.com/pybind/pybind11_protobuf.git",
 )
+
+# extendedlogging python library for traceviewer and python autologging
+git_repository(
+    name = "extendedlogging",
+    remote = "https://github.com/janfeitsma/extendedlogging.git",
+    commit = "2602efe3790fdd97f2b22808f7f35da0272fc83c",
+    build_file = "//dependencies/bazel:BUILD.extendedlogging",
+)
+

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -114,7 +114,7 @@ git_repository(
 git_repository(
     name = "extendedlogging",
     remote = "https://github.com/janfeitsma/extendedlogging.git",
-    commit = "2602efe3790fdd97f2b22808f7f35da0272fc83c",
+    commit = "9e969e3b4dee599c506d8603f0e46edbd53a0f5f",
     build_file = "//dependencies/bazel:BUILD.extendedlogging",
 )
 

--- a/components/falcons/localization_vision/test/BUILD
+++ b/components/falcons/localization_vision/test/BUILD
@@ -31,6 +31,7 @@ py_binary(
     data = [
         ":pybind_ext.so",
         "@com_google_protobuf//:protobuf_python",
+        "@extendedlogging//:extendedlogging",
     ],
 )
 

--- a/components/falcons/localization_vision/test/tracing.py
+++ b/components/falcons/localization_vision/test/tracing.py
@@ -2,19 +2,8 @@ import sys, os
 import inspect
 from types import FunctionType, ModuleType
 
+import extendedlogging.extendedlogging as extendedlogging
 
-IMPORT_SUCCESS = False
-try:
-    import extendedlogging
-    IMPORT_SUCCESS = True
-except ImportError:
-    p = '/home/jan/hobby/extendedlogging'
-    if os.path.isdir(p):
-        sys.path.append(p)
-        import extendedlogging
-        IMPORT_SUCCESS = True
-    else:
-        print('WARNING: could not find extendedlogging module')
 
 
 # MAGIC!
@@ -69,7 +58,7 @@ def auto_decorate():
         decorate_module(m)
 
 
-if IMPORT_SUCCESS:
+if True:
     # Now call the decorate_all function here so that the decorator is automatically applied
     auto_decorate()
     decorate_module(get_parent_module())

--- a/components/falcons/localization_vision/test/tune.py
+++ b/components/falcons/localization_vision/test/tune.py
@@ -233,8 +233,8 @@ def main(args: argparse.Namespace) -> None:
     Run the tuning tool.
     """
     if args.debug:
-        # JFEI-private debugging (based on autologging extensions in my repo https://github.com/janfeitsma/extendedlogging)
         # slap some tracing decorators onto our code, automagically!
+        # (based on autologging extensions in my repo https://github.com/janfeitsma/extendedlogging)
         import tracing
     else:
         logging.basicConfig(format=LOGGING_FORMAT)

--- a/components/falcons/test_mra_logger/src/test_helpers.cpp
+++ b/components/falcons/test_mra_logger/src/test_helpers.cpp
@@ -9,7 +9,7 @@
 MRA::Datatypes::LogControl testConfiguration() {
     MRA::Datatypes::LogControl result = MRA::Logging::control::defaultConfiguration();
     result.set_folder(LOG_FOLDER_TEST);
-    result.set_filename("<maincomponent>.log");
+    result.set_filename("<maincomponent>.spdlog");
     result.mutable_general()->set_component("MRA-test");
     result.mutable_general()->set_level(MRA::Datatypes::LogLevel::INFO);
     result.mutable_general()->set_enabled(true);

--- a/components/falcons/test_mra_logger/test.cpp
+++ b/components/falcons/test_mra_logger/test.cpp
@@ -9,7 +9,7 @@
 #include "logging.hpp"
 #include "FalconsTestMraLogger.hpp"
 
-std::string EXPECTED_LOG_FILE = LOG_FOLDER_TEST "/FalconsTestMraLogger.log";
+std::string EXPECTED_LOG_FILE = LOG_FOLDER_TEST "/FalconsTestMraLogger.spdlog";
 
 
 // Helper function: manipulate logger to run independent of everything else, via environment

--- a/datatypes/Logging.proto
+++ b/datatypes/Logging.proto
@@ -30,7 +30,7 @@ message LogSpec
 message LogControl
 {
     string folder = 1; // folder to write to, default auto-create in /tmp, something like /tmp/mra_logging
-    string filename = 2; // filename to use, default "<maincomponent>_<pid>.log" (supports logging nested components into same file)
+    string filename = 2; // filename to use, default "<maincomponent>_<pid>.spdlog" (supports logging nested components into same file)
     LogSpec general = 3; // settings to use if no component overrule is specified
     repeated LogSpec overrules = 4; // component overrules, when not specified, use general settings
 }

--- a/dependencies/bazel/BUILD.extendedlogging
+++ b/dependencies/bazel/BUILD.extendedlogging
@@ -1,0 +1,18 @@
+
+py_library(
+    name = "extendedlogging",
+    srcs = [
+        "extendedlogging.py",
+        "patch_autologging.py",
+        "ttvlib/ttparse.py",
+        "ttvlib/ttconvert/runner.py",
+        "ttvlib/ttconvert/registry.py",
+        "ttvlib/ttconvert/standard.py",
+        "ttvlib/ttconvert/__init__.py",
+        "ttvlib/ttviewer.py",
+        "ttvlib/ttstore.py",
+        "ttvlib/__init__.py",
+    ],
+    visibility = ["//visibility:public"],
+)
+

--- a/libraries/logging/backend.cpp
+++ b/libraries/logging/backend.cpp
@@ -217,7 +217,7 @@ void replaceAll(std::string &s, const std::string &search, const std::string &re
 
 std::string MraLogger::determineFileName(std::string const &cname)
 {
-    // Default file name configuration is something like "<maincomponent>_<pid>.log".
+    // Default file name configuration is something like "<maincomponent>_<pid>.spdlog".
     // The <placeholders> need to be filled in.
     // Get the pattern. It may be customized at start of main execution using logger setFileName.
     std::string result = m_filename_pattern;

--- a/libraries/logging/check_logfolder.py
+++ b/libraries/logging/check_logfolder.py
@@ -117,7 +117,7 @@ def get_folder_contents(folder_path, load_all=False):
     result = {}
     for root, _, files in os.walk(folder_path):
         for file in files:
-            if not file.endswith('.log'):
+            if not file.endswith('.spdlog'):
                 continue
             file_path = os.path.join(root, file)
             if load_all:

--- a/libraries/logging/control.cpp
+++ b/libraries/logging/control.cpp
@@ -83,7 +83,7 @@ MRA::Datatypes::LogControl defaultConfiguration()
 {
     MRA::Datatypes::LogControl result;
     result.set_folder(_mkLogFolder());
-    result.set_filename("<maincomponent>_<pid>.log");
+    result.set_filename("<maincomponent>_<pid>.spdlog");
     result.mutable_general()->set_component("MRA");
     std::string level_str = "INFO";
     char const *cp = getenv(LOG_LEVEL_KEY.c_str());

--- a/libraries/logging/control.hpp
+++ b/libraries/logging/control.hpp
@@ -14,7 +14,7 @@ namespace MRA::Logging::control
 // get the logging folder, may create if needed
 std::string getLogFolder();
 
-// logger file name pattern, something like "<maincomponent>_<pid>.log"
+// logger file name pattern, something like "<maincomponent>_<pid>.spdlog"
 std::string getFileNamePattern();
 
 // configure


### PR DESCRIPTION
New script to view and analyze generated tracing.

Example + screenshot:

1. run full test suite, with option to generate some tracing: `MRA-build.py -t -T`
2. run script on the tracing folder: `MRA-traceview.py /tmp/testsuite_mra_logging/`
3. you should see something like this, use (w,a,s,d) keys to scroll and zoom, click any function call block to see details
![image](https://github.com/RoboCup-MSL/MRA-components/assets/24246517/62dee53f-e9e2-4ce7-a93c-6b828f71d7e5)

Note: it has a hacky dependency on my `extendedlogging` repo. I kind of solved it for bazel, not yet generally in a user friendly way ...