### PR TITLE
cpp checker fixes

### DIFF
--- a/libraries/geometry/tmp_vector2d.hpp
+++ b/libraries/geometry/tmp_vector2d.hpp
@@ -35,19 +35,9 @@ class Vector2D
             return (*this);
         }
 
-        double& operator [](long k)
-        {
-            return ((&x)[k]);
-        }
-
         double size() const
         {
             return sqrt(x*x+y*y);
-        }
-
-        const double& operator [](long k) const
-        {
-            return ((&x)[k]);
         }
 
         Vector2D& operator +=(const Vector2D& v)

--- a/libraries/logging/backend.cpp
+++ b/libraries/logging/backend.cpp
@@ -342,7 +342,6 @@ void MraLogger::log(source_loc loc, MRA::Logging::LogLevel loglevel, const char 
             s_spdlog_logger->log(loc_spd, spdlog::level::trace, s);
             break;
         }
-        va_end(argptr);
         // TODO: why is flush needed here, why doesn't flush_on at setup() seem to work?
         s_spdlog_logger->flush();
     }


### PR DESCRIPTION
Executed cppchecker over MRA.   
3 issue found:  
* 2 issues in tmp_vector2d.hpp: both in a unused function. Solution: remove the unsafe unused functions.
* 1 issue in logging/backend.cpp. Usage of va_end with va_begin.   solution: removed va_end.