### PR TITLE
MRA-build cmake: create build dir if not exists

### DIFF
--- a/MRA-build.py
+++ b/MRA-build.py
@@ -128,7 +128,7 @@ class CmakeBuilder(Builder):
         self.run_cmd('rm -rf build; mkdir build')
     def run_build(self, scope: list, jobs: int = DEFAULT_NUM_PARALLEL_JOBS) -> None:
         # TODO: do something with scope, it currently only works for bazel, so now everyone gets a "full" build
-        self.run_cmd('cd build; cmake .. -G "Unix Makefiles"') # TODO: also support ninja?
+        self.run_cmd('mkdir build; cd build; cmake .. -G "Unix Makefiles"') # TODO: also support ninja?
         self.run_cmd(f'cd build; make -j {jobs}')
     def run_test(self, scope: list, tracing: bool = False, extra_args: list = []) -> None:
         cmd = f'cd build; ctest --rerun-failed --output-on-failure'


### PR DESCRIPTION
make cmake option robust for situation that build does not exists.