### PR TITLE
add dynamicrole to datatypes

### DIFF
--- a/datatypes/CMakeLists.txt
+++ b/datatypes/CMakeLists.txt
@@ -7,6 +7,7 @@ set(MESSAGE_PROTOS_COMMON
     Ball.proto
     BallCandidate.proto
     CvMat.proto
+    DynamicRole.proto
     Logging.proto
     Meta.proto
     Obstacle.proto

--- a/datatypes/DynamicRole.proto
+++ b/datatypes/DynamicRole.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package MRA.Datatypes;
+
+enum DynamicRole
+{
+    UNDEFINED = 0;
+    GOALKEEPER = 1;
+    ATTACKER_MAIN = 2;
+    ATTACKER_ASSIST = 3;
+    ATTACKER_GENERIC = 4;
+    DEFENDER_MAIN = 5;
+    DEFENDER_GENERIC = 6;
+    DISABLED_OUT = 7;
+    DISABLED_IN = 8;
+}


### PR DESCRIPTION
the dynamic role is a datatype which can be used by multiple components and is generic (similar to mixed team protocol)