### PR TITLE
update github workflows: use bazelbuild/setup-bazelisk@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Bazel
-      uses: bazelbuild/setup-bazelisk@v2
+      uses: bazelbuild/setup-bazelisk@v3
 
     - name: Set up dependencies
       run: |
@@ -39,7 +39,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Bazel
-      uses: bazelbuild/setup-bazelisk@v2
+      uses: bazelbuild/setup-bazelisk@v3
 
     - name: Set up dependencies
       run: |
@@ -63,7 +63,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Bazel
-      uses: bazelbuild/setup-bazelisk@v2
+      uses: bazelbuild/setup-bazelisk@v3
 
     - name: Set up dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_policy(SET CMP0077 NEW) # option() command to do nothing when a normal var
 option(MRA_TEST_ENABLED "Build all tests" ON)
 
 # use C++17 standard, or suffer errors re. using std::filesystem
-set(CMAKE_CXX_FLAGS "-std=c++17 -Wall -Werror -Wno-address -Wno-reorder -Wno-array-bounds -Wno-error=nonnull-compare")
+set(CMAKE_CXX_FLAGS "-std=c++17 -Wall -Werror -Wno-address -Wno-reorder -Wno-array-bounds -Wno-error=nonnull-compare -g")
  # to prevent compiler errors added the not preferred flags: -Wno-address -Wno-reorder -Wno-array-bounds 
 
 # dependency: ProtoBuf


### PR DESCRIPTION
update github flow for the bazel builds to new setup-bazelisk (v3). 
Version v2 is phasing out.