### PR TITLE
Logging disable compiletime

### DIFF
--- a/components/falcons/localization_vision/internal/fit.cpp
+++ b/components/falcons/localization_vision/internal/fit.cpp
@@ -23,9 +23,11 @@ void fitThreadFunction(FitCore& _fitCore, cv::Mat const &referenceFloor, std::ve
 
 void FitAlgorithm::run(cv::Mat const &referenceFloor, std::vector<cv::Point2f> const &rcsLinePoints, std::vector<Tracker> &trackers)
 {
-    int num_trackers_before = trackers.size();
     int num_threads = std::min(1, settings.numextrathreads());
+#ifdef MRA_LOGGING_ENABLED
+    int num_trackers_before = trackers.size();
     MRA_TRACE_FUNCTION_INPUTS(num_trackers_before, num_threads);
+#endif
 
     // multithreaded execution (main thread idle)
     {
@@ -37,16 +39,20 @@ void FitAlgorithm::run(cv::Mat const &referenceFloor, std::vector<cv::Point2f> c
         // wait via ~ThreadPool
     }
 
+#ifdef MRA_LOGGING_ENABLED
     int num_trackers_after = trackers.size();
     MRA_TRACE_FUNCTION_OUTPUTS(num_trackers_after);
+#endif
 }
 
 FitResult FitCore::run(cv::Mat const &referenceFloor, std::vector<cv::Point2f> const &rcsLinePoints, MRA::Geometry::Pose const &guess, MRA::Geometry::Pose const &step)
 {
-    int numpoints = rcsLinePoints.size();
     MRA::Datatypes::Pose guess_ = guess;
     MRA::Datatypes::Pose step_ = step;
+#ifdef MRA_LOGGING_ENABLED
+    int numpoints = rcsLinePoints.size();
     MRA_TRACE_FUNCTION_INPUTS(numpoints, guess_, step_);
+#endif
     FitResult result;
 
     // sanity checks
@@ -130,8 +136,10 @@ cv::Mat FitFunction::transform3dof(cv::Mat const &m, double x, double y, double 
 
 std::vector<cv::Point2f> FitFunction::transformPoints(const std::vector<cv::Point2f> &points, cv::Mat const tmat) const
 {
+#ifdef MRA_LOGGING_ENABLED
     int n = points.size();
     MRA_TRACE_FUNCTION_INPUTS(n, tmat);
+#endif
 
     // Nothing to do?
     if (points.size() == 0)

--- a/components/falcons/localization_vision/internal/floor.cpp
+++ b/components/falcons/localization_vision/internal/floor.cpp
@@ -130,8 +130,10 @@ void Floor::letterModelToShapes(StandardLetterModel const &model, std::vector<MR
             shapes.push_back(s);
         }
     }
+#ifdef MRA_LOGGING_ENABLED
     int numShapes = shapes.size();
     MRA_TRACE_FUNCTION_OUTPUT(numShapes);
+#endif
 }
 
 cv::Point Floor::pointFcsToPixel(MRA::Datatypes::Point const &p) const
@@ -221,8 +223,10 @@ int Floor::blurSinglePass(cv::Mat &image, std::vector<cv::Point> &whitePixels, f
 
 void Floor::shapesToCvMat(std::vector<MRA::Datatypes::Shape> const &shapes, cv::Mat &m) const
 {
+#ifdef MRA_LOGGING_ENABLED
     int numShapes = shapes.size();
     MRA_TRACE_FUNCTION_INPUTS(numShapes);
+#endif
     cv::Scalar color(255, 255, 255); // white
     for (auto const &s: shapes)
     {

--- a/components/falcons/localization_vision/internal/guessing.cpp
+++ b/components/falcons/localization_vision/internal/guessing.cpp
@@ -36,8 +36,10 @@ std::optional<MRA::Geometry::Point> Guesser::tryGuess(std::vector<MRA::Geometry:
 
 void Guesser::run(std::vector<Tracker> &trackers, Params const &params, bool initial) const
 {
+#ifdef MRA_LOGGING_ENABLED
     int num_trackers = trackers.size();
     MRA_TRACE_FUNCTION_INPUTS(num_trackers, initial);
+#endif
 
     // if so configured, add new fit attempts (as trackers)
     // so that the fit algorithm can run them all

--- a/components/falcons/localization_vision/test.cpp
+++ b/components/falcons/localization_vision/test.cpp
@@ -85,8 +85,10 @@ TEST(FalconsLocalizationVisionTest, referenceFloor)
 // Template for testing calculation/scoring function - 0.0 is perfect, 1.0 is worst
 double FalconsLocalizationVisionTestCalc(std::vector<cv::Point2f> const &points, double x, double y, double rz)
 {
+#ifdef MRA_LOGGING_ENABLED
     int n = points.size();
     MRA_TRACE_FUNCTION_INPUTS(n, x, y, rz);
+#endif
     // Arrange
     auto m = FalconsLocalizationVision::FalconsLocalizationVision();
     auto params = m.defaultParams();
@@ -113,8 +115,10 @@ std::vector<cv::Point2f> makeFieldPoints(double szx, double szy)
     result.push_back(cv::Point2f(-x, 0.0));
     result.push_back(cv::Point2f(0.0, y));
     result.push_back(cv::Point2f(0.0, -y));
+#ifdef MRA_LOGGING_ENABLED
     int n = result.size();
     MRA_TRACE_FUNCTION_OUTPUTS(n);
+#endif
     return result;
 }
 
@@ -134,8 +138,10 @@ std::vector<cv::Point2f> makeCirclePoints(double radius, bool diagonal)
         result.push_back(cv::Point2f(-s, s));
         result.push_back(cv::Point2f(-s, -s));
     }
+#ifdef MRA_LOGGING_ENABLED
     int n = result.size();
     MRA_TRACE_FUNCTION_OUTPUTS(n);
+#endif
     return result;
 }
 

--- a/components/falcons/test_mra_logger/test.cpp
+++ b/components/falcons/test_mra_logger/test.cpp
@@ -179,9 +179,14 @@ TEST_F(TestFixture, demoFunctions) {
 }
 
 int main(int argc, char **argv) {
+    // only run this testsuite if the macros are enabled at compiletime
+#if MRA_LOGGING_ENABLED
     configure_logger();
     testing::InitGoogleTest(&argc, argv);
     int r = RUN_ALL_TESTS();
+#else
+    int r = 0;
+#endif
     return r;
 }
 

--- a/components/robotsports/local_ball_tracking/internal/sequence_clustering_track_ball.cpp
+++ b/components/robotsports/local_ball_tracking/internal/sequence_clustering_track_ball.cpp
@@ -112,6 +112,7 @@ static sc_result_e init_hyp(hypothesis_t hypothesises[MAXHYP]) {
 }
 
 
+#ifdef MRA_LOGGING_ENABLED
 static std::string SC_result_to_string(sc_result_e result) {
     std::string result_string = "";
     switch (result) {
@@ -140,6 +141,7 @@ static std::string SC_result_to_string(sc_result_e result) {
 
     return result_string;
 }
+#endif
 
 static sc_result_e fbuf_add(hypothesis_t& r_hypothesis,
                             const ball_candidate_t& ball_candidate,

--- a/libraries/logging/BUILD
+++ b/libraries/logging/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "logging",
     hdrs = [
         "logging.hpp", # main header, others are helpers/subcomponents
+        "dummies.hpp",
         "frontend.hpp",
         "backend.hpp",
         "logtick.hpp",

--- a/libraries/logging/dummies.hpp
+++ b/libraries/logging/dummies.hpp
@@ -1,0 +1,23 @@
+#ifndef _MRA_LIBRARIES_LOGGING_DUMMIES_HPP
+#define _MRA_LIBRARIES_LOGGING_DUMMIES_HPP
+
+
+// use these macros to disable logging compile-time
+// the real definitions are in libraries/logging/macros.hpp
+
+#define MRA_LOG_TICK() do {} while (0)
+#define MRA_COMPONENT_NAME "undefined"
+#define MRA_LOG_CRITICAL(...) do {} while (0)
+#define MRA_LOG_ERROR(...) do {} while (0)
+#define MRA_LOG_WARNING(...) do {} while (0)
+#define MRA_LOG_INFO(...) do {} while (0)
+#define MRA_LOG_DEBUG(...) do {} while (0)
+#define MRA_TRACE_FUNCTION() do {} while (0)
+#define MRA_TRACE_TEST_FUNCTION() do {} while (0)
+#define MRA_TRACE_FUNCTION_INPUTS(...) do {} while (0)
+#define MRA_TRACE_FUNCTION_OUTPUTS(...) do {} while (0)
+#define MRA_TRACE_FUNCTION_INPUT(varname) do {} while (0)
+#define MRA_TRACE_FUNCTION_OUTPUT(varname) do {} while (0)
+
+#endif // #ifndef _MRA_LIBRARIES_LOGGING_DUMMIES_HPP
+

--- a/libraries/logging/dummies.hpp
+++ b/libraries/logging/dummies.hpp
@@ -6,7 +6,6 @@
 // the real definitions are in libraries/logging/macros.hpp
 
 #define MRA_LOG_TICK() do {} while (0)
-#define MRA_COMPONENT_NAME "undefined"
 #define MRA_LOG_CRITICAL(...) do {} while (0)
 #define MRA_LOG_ERROR(...) do {} while (0)
 #define MRA_LOG_WARNING(...) do {} while (0)

--- a/libraries/logging/logging.hpp
+++ b/libraries/logging/logging.hpp
@@ -1,6 +1,9 @@
 #ifndef _MRA_LIBRARIES_LOGGING_HPP
 #define _MRA_LIBRARIES_LOGGING_HPP
 
+// comment this out to disable all macros as no-ops
+//#define MRA_LOGGING_ENABLED
+
 #include "levels.hpp"
 #include "backend.hpp"
 #include "frontend.hpp"

--- a/libraries/logging/macros.hpp
+++ b/libraries/logging/macros.hpp
@@ -1,6 +1,12 @@
 #ifndef _MRA_LIBRARIES_LOGGING_MACROS_HPP
 #define _MRA_LIBRARIES_LOGGING_MACROS_HPP
 
+
+#ifndef MRA_LOGGING_ENABLED
+#include "dummies.hpp"
+#else
+
+
 #include "logtick.hpp"
 #include "backend.hpp"
 
@@ -64,6 +70,8 @@
 #define MRA_TRACE_FUNCTION_OUTPUT_PAIR(v) scoped.add_output(#v, v);
 #define MRA_TRACE_FUNCTION_OUTPUTS(...) \
     MAP(MRA_TRACE_FUNCTION_OUTPUT_PAIR, __VA_ARGS__) \
+
+#endif // #ifndef else MRA_LOGGING_ENABLED
 
 #endif // #ifndef _MRA_LIBRARIES_LOGGING_MACROS_HPP
 


### PR DESCRIPTION
MRA logging and tracing appears to be a significant performance hit.
We could invest time in solving this, but I personally don't use it as often as before anyway. (I just make sure I have all data in output&diagnostics and log it at client side, for instance, action_planning action diagnostics files & plotter.)

So for now, just add a compiletime switch.
