### PR TITLE
Ros2 with pixi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bazel-*
 build/
 .vscode/
 __pycache__/
+/install/*
+/log/*

--- a/components/common/mra_msgs/CMakeLists.txt
+++ b/components/common/mra_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(mra_common_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/components/common/mra_tracing/CMakeLists.txt
+++ b/components/common/mra_tracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(mra_tracing)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/components/falcons/action_planning/CMakeLists.txt
+++ b/components/falcons/action_planning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(mra_falcons_action_planning)
 
 # Find dependencies

--- a/components/falcons/configuration/CMakeLists.txt
+++ b/components/falcons/configuration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(mra_falcons_configuration)
 
 find_package(ament_cmake REQUIRED)

--- a/components/falcons/falcons_msgs/CMakeLists.txt
+++ b/components/falcons/falcons_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(mra_falcons_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/components/falcons/setpoint_calculation/CMakeLists.txt
+++ b/components/falcons/setpoint_calculation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(mra_falcons_setpoint_calculation)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/components/falcons/teamplay/CMakeLists.txt
+++ b/components/falcons/teamplay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(mra_falcons_teamplay)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,22451 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/robostack-humble/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.1-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.13-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-3.25-hbd00459_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-h7db5c69_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.10.0-h2b85faf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-20-20.1.7-default_h1df26ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-20.1.7-default_h1df26ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.26.4-hcfe8598_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cmake-0.2.28-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/colcon-common-extensions-0.3.0-py311h38be061_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-core-0.19.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-defaults-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-devtools-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-library-path-0.2.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-test-result-0.3.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-zsh-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.10.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.17.1-py311hca438b8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py311hafd3f86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.10.0-h1a2810e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hb7c51ca_708.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h783367e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h07f6e7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.10.0-h36df796_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.6.0-py311h62d540b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-h1e990d8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-h6f18a23_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.24.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.24.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-13.3.0-h9576a4e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.3.0-h84c1745_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.3.0-h1917dac_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.84.2-h6287aef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.84.2-h4833e2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.15.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hae580e1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-hb14504d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.2.1-h3beb420_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_109.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.5-h1920b20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h52826cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-32_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-h6c02f8c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.86.0-h1a2810e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.86.0-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py311h5b7b71f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-32_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.7-default_h1df26ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.7-default_he06ed0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.13.3-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.13.3-h48d6fc4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-hc03c837_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.2-h3618099_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-cmake2-2.17.2-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-math6-6.15.1-py311he92c4ec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-32_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-32_he2f377e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.7-he9d0ab4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py311h8702e32_613.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.5.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.5.0-h4d9b6c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.5.0-h4d9b6c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.5.0-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.5.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.5.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.5.0-hac27bb2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.5.0-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.5.0-h5c8f2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.5.0-h5c8f2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.5.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.5.0-h6481b9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.5.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.49-h943b412_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-he8ea267_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.2-h6cd9bfd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-hc03c837_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.10-h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.10.0-h65c71a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py311hbd2c71b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.3-py311h2b939e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.0-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.3.0-h266115a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.3.0-he0572af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netifaces-0.11.0-py311h9ecbd09_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.0-h7aa8ee6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.113-h159eef7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.4-h2cd1444_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.5.0-hf92e6e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-h5888daf_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.3-h9ac818e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcl-1.14.1-h679aaff_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.10.0-qt6_py311h9d93fc6_613.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyhc790b64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh217bc35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pybullet-3.25-py311h2ed89a0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.28.0-py311hd785cd9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydot-4.0.1-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311he22028a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.15.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py311hfdbb021_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hea1682b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.8.3-h75f3359_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.3-hd590300_2.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-msgs-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-cpp-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-interfaces-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-py-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-actionlib-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-clang-format-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-auto-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-clang-format-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-core-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-python-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-ros-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-test-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-version-1.3.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-copyright-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cppcheck-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cpplint-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-flake8-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-cpp-1.4.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-python-1.4.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-auto-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-common-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-package-0.14.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-pep257-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-uncrustify-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-xmllint-0.12.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-angles-1.15.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-builtin-interfaces-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-class-loader-2.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-common-interfaces-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-composition-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-composition-interfaces-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-console-bridge-vendor-1.4.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-cv-bridge-3.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-cyclonedds-0.10.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-cpp-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-cpp-native-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-py-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-depthimage-to-laserscan-2.5.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-desktop-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-diagnostic-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-domain-coordinator-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-map-server-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-robot-bringup-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-sensors-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-example-interfaces-0.9.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-action-client-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-action-server-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-client-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-composition-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-publisher-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-service-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-subscriber-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-timer-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-multithreaded-executor-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-executors-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-action-client-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-action-server-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-client-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-publisher-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-service-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-subscriber-0.15.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastcdr-1.0.24-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-2.6.9-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry2-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gmock-vendor-1.10.9006-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gtest-vendor-1.10.9006-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-posh-2.0.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-geometry-3.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-tools-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-transport-3.1.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-interactive-markers-2.3.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-intra-process-demo-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-joy-3.3.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-kdl-parser-2.6.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-keyboard-handler-0.0.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-laser-geometry-2.4.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-1.0.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-ros-0.19.8-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-1.0.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ros-0.19.8-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-xml-1.0.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-yaml-1.0.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libcurl-vendor-3.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libstatistics-collector-1.3.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libyaml-vendor-1.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-lifecycle-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-lifecycle-msgs-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-logging-demo-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-map-msgs-2.1.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-message-filters-4.3.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-nav-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-osrf-pycommon-2.1.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pcl-conversions-2.4.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pcl-msgs-1.0.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pendulum-control-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pendulum-msgs-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pluginlib-5.1.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pybind11-vendor-2.4.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-python-cmake-module-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-python-qt-binding-1.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-dotgraph-2.2.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-2.2.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-cpp-2.2.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-py-common-2.2.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-quality-of-service-demo-cpp-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-quality-of-service-demo-py-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-5.3.9-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-action-5.3.9-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-interfaces-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-lifecycle-5.3.9-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-interface-2.3.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h6a008e1_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-16.0.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-action-16.0.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-components-16.0.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclpy-3.3.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcpputils-2.4.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcutils-5.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-resource-retriever-3.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-6.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-0.11.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-dds-common-1.6.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-2.8.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-robot-state-publisher-3.0.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-base-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-environment-3.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-workspace-1.0.2-np126py311h2c3b307_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2action-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2bag-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-0.18.11-np126py311hdfa6bdf_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2component-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2doctor-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2interface-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2launch-0.19.8-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2lifecycle-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2multicast-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2node-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2param-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2pkg-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2run-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2service-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2topic-0.18.11-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-cpp-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-py-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-transport-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosgraph-msgs-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-adapter-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cli-3.1.6-np126py311hdfa6bdf_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cmake-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-generators-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-c-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-py-0.14.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-parser-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rpyutils-0.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-action-2.0.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-bag-1.1.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-bag-plugins-1.1.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-common-plugins-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-console-2.0.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-graph-1.3.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-1.1.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-cpp-1.1.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-py-1.1.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-image-view-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-msg-1.2.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-plot-1.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-publisher-1.5.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-py-common-1.1.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-py-console-1.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-reconfigure-1.1.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-service-caller-1.0.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-shell-1.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-srv-1.0.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-topic-1.5.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rttest-0.13.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-common-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-default-plugins-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-rendering-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz2-11.2.15-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sdl2-vendor-3.3.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-py-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shape-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shared-queues-vendor-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-spdlog-vendor-1.3.1-np126py311h6a008e1_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sqlite3-vendor-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-0.10.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-cmake-0.10.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-statistics-msgs-1.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-srvs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-stereo-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tango-icons-vendor-0.1.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-teleop-twist-joy-2.4.7-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-teleop-twist-keyboard-2.4.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-bullet-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-kdl-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-msgs-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-py-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-py-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-tools-0.25.10-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml-vendor-0.8.3-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tlsf-0.7.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tlsf-cpp-0.13.0-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-topic-monitor-0.20.5-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tracetools-4.1.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-trajectory-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-turtlesim-1.4.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-uncrustify-vendor-2.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-2.6.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-3.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-headers-1.0.6-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-visualization-msgs-4.2.4-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-zstd-vendor-0.15.13-np126py311h2c3b307_7.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-64/ros2-distro-mutex-0.6.0-humble_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.16-he3e324a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py311hfdbb021_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.2-hb7a22d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.1.0-h4ce085d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h3f2d84a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.74.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.6-h005c6e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-9.3.1-qt_py311h71fb23e_215.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.3.1-qt_py311h75c0fa1_215.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-io-ffmpeg-9.3.1-qt_py311h71fb23e_215.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.45-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.45-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.1-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.12.13-py311h58d527c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.1.0-h86ecc28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.1.0-h86ecc28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-3.25-h58b41f2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-cpp-3.25-py311h848c333_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.10.0-h6561dab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.17.1-py311h14e8bb7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-20-20.1.7-default_h7d4303a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-20.1.7-default_h7d4303a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.26.4-hef020d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cmake-0.2.28-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/colcon-common-extensions-0.3.0-py311hec3470c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-core-0.19.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-defaults-0.2.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-devtools-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-library-path-0.2.1-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-test-result-0.3.8-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colcon-zsh-0.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compilers-1.10.0-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.2-py311hc07b1fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.9.1-py311ha09ea12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.17.1-py311h06690bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-45.0.4-py311h4047cc9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.10.0-heb6c788_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.7.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_h013846f_708.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-ha858f50_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-11.0.2-h97e1849_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.58.4-py311h58d527c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fortran-compiler-1.10.0-h25a59a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.13.3-h8af1aa0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.6.0-py311ha6a3852_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-h80a1502_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.24.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.24.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-13.3.0-h8a56e6e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-13.3.0-h9c0531c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-13.3.0-h2809cf8_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gl2ps-1.4.2-hedfd65a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.84.2-h5702d23_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.84.2-h78ca943_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.15.2-h8af1aa0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-12.2.1-h044d27a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.15.2-h70be974_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hc7d089d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h7eae8fb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-11.2.1-h405b6a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h6ed7ac7_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.5-h9d5db0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jsoncpp-1.9.6-h34915d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.7-py311h75754e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.17-hc88f144_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h18dbdb1_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.4-h1e66f74_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.24.1-h5e0f5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.24.1-h5e0f5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-h3c9f632_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-32_h1a9f1db_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-h4d13611_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.86.0-h37bb5a9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.86.0-py311hb9acf69_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h86ecc28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h86ecc28_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.75-h51d75a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-32_hab92f65_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.7-default_h7d4303a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-20.1.7-default_h9e36cb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.14.1-h6702fde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.24-he377734_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.13.3-h8af1aa0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.13.3-he93130f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.24.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.24.1-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.84.2-hc022ef1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.55-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.2-default_h2c612a5_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-hc99b53d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-cmake2-2.17.2-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-math6-6.15.1-py311hafc0cf7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-32_h411afd4_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-32_hc659ca5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.7-h07bd352_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h46655bb_116.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py311h285173e_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.5.0-hd7d4d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.5.0-hd7d4d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.5.0-hf15766e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.5.0-hf15766e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.5.0-h6ef32b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.5.0-h6ef32b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.5.0-haa99d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.5.0-haa99d6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.5.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.5.0-he24a241_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.5.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.5.2-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.49-hec79eb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.5-hf590da8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h3ac5bce_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.50.2-he2a92bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.7-h2bb824b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtheora-1.1.1-h68df207_1006.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-h7c15681_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.7-h7b9e449_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.6.2-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.10-h17cf362_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libusb-1.0.29-h06eaf92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.5.0-h0886dbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.10.0-hbab7b08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.8-he060846_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-6.0.0-py311h3bfafd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.3-py311h0385ec1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.1.1-py311hc07b1fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/multidict-6.6.0-py311h58d527c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/netifaces-0.11.0-py311ha879c10_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.0-ha6136e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.113-h7e26b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.4-h718fb27_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.5.0-h6c5ec6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.3-h3f56577_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-h5ad3122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.3-h1e6a6fd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcl-1.14.1-h29e8f2a_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.2.1-py311ha4eaa5e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.2-h86a87f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.5.1-h9655f4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/propcache-0.3.1-py311h58d527c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.0.0-py311ha879c10_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.10.0-headless_py311h41de8d1_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyhc790b64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh217bc35_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybullet-3.25-py311h7b00dee_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pycairo-1.28.0-py311h0c1bbf2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pydot-4.0.1-py311hec3470c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py311h70a6756_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.15.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py311h89d996e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.13-h1683364_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py311h58d527c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hf34aa0b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.3-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-msgs-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-cpp-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-interfaces-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-py-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-actionlib-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-clang-format-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-auto-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-clang-format-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-core-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-python-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-ros-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-test-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-version-1.3.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-copyright-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cppcheck-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cpplint-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-flake8-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-index-cpp-1.4.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-index-python-1.4.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-auto-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-cmake-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-common-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-package-0.14.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-pep257-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-uncrustify-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-xmllint-0.12.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-angles-1.15.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-builtin-interfaces-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-class-loader-2.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-common-interfaces-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-composition-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-composition-interfaces-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-console-bridge-vendor-1.4.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-cv-bridge-3.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-cyclonedds-0.10.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-cpp-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-cpp-native-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-py-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-depthimage-to-laserscan-2.5.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-desktop-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-diagnostic-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-domain-coordinator-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-map-server-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-robot-bringup-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-sensors-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-example-interfaces-0.9.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-action-client-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-action-server-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-client-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-composition-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-publisher-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-service-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-subscriber-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-timer-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-multithreaded-executor-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-executors-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-action-client-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-action-server-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-client-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-publisher-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-service-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-subscriber-0.15.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastcdr-1.0.24-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-2.6.9-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-geometry-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-geometry2-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gmock-vendor-1.10.9006-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gtest-vendor-1.10.9006-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-posh-2.0.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-geometry-3.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-tools-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-transport-3.1.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-interactive-markers-2.3.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-intra-process-demo-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-joy-3.3.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-kdl-parser-2.6.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-keyboard-handler-0.0.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-laser-geometry-2.4.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-1.0.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-ros-0.19.8-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-1.0.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-ros-0.19.8-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-xml-1.0.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-yaml-1.0.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libcurl-vendor-3.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libstatistics-collector-1.3.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libyaml-vendor-1.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-lifecycle-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-lifecycle-msgs-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-logging-demo-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-map-msgs-2.1.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-message-filters-4.3.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-nav-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-osrf-pycommon-2.1.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pcl-conversions-2.4.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pcl-msgs-1.0.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pendulum-control-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pendulum-msgs-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pluginlib-5.1.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pybind11-vendor-2.4.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-python-cmake-module-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-python-qt-binding-1.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-dotgraph-2.2.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-2.2.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-cpp-2.2.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-py-common-2.2.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-quality-of-service-demo-cpp-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-quality-of-service-demo-py-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-5.3.9-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-action-5.3.9-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-interfaces-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-lifecycle-5.3.9-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-logging-interface-2.3.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h1db7994_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-16.0.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-action-16.0.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-components-16.0.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclpy-3.3.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcpputils-2.4.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcutils-5.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-resource-retriever-3.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-6.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-0.11.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-dds-common-1.6.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-2.8.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-robot-state-publisher-3.0.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-base-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-core-0.10.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-environment-3.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-workspace-1.0.2-np126py311h65a17ee_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2action-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2bag-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2cli-0.18.11-np126py311hdeb5fcf_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2component-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2doctor-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2interface-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2launch-0.19.8-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2lifecycle-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2multicast-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2node-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2param-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2pkg-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2run-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2service-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2topic-0.18.11-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-compression-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-cpp-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-py-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-storage-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-transport-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosgraph-msgs-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-adapter-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-cli-3.1.6-np126py311hdeb5fcf_9.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-cmake-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-default-generators-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-c-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-py-0.14.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-parser-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rpyutils-0.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-action-2.0.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-bag-1.1.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-bag-plugins-1.1.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-common-plugins-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-console-2.0.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-graph-1.3.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-1.1.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-cpp-1.1.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-py-1.1.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-image-view-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-msg-1.2.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-plot-1.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-publisher-1.5.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-py-common-1.1.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-py-console-1.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-reconfigure-1.1.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-service-caller-1.0.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-shell-1.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-srv-1.0.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-topic-1.5.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rttest-0.13.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-common-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-default-plugins-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-rendering-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz2-11.2.15-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sdl2-vendor-3.3.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-py-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-shape-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-shared-queues-vendor-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-spdlog-vendor-1.3.1-np126py311h1db7994_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sqlite3-vendor-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sros2-0.10.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sros2-cmake-0.10.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-statistics-msgs-1.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-std-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-std-srvs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-stereo-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tango-icons-vendor-0.1.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-teleop-twist-joy-2.4.7-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-teleop-twist-keyboard-2.4.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-bullet-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-kdl-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-msgs-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-py-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-ros-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-ros-py-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-tools-0.25.10-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tinyxml-vendor-0.8.3-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tlsf-0.7.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tlsf-cpp-0.13.0-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-topic-monitor-0.20.5-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tracetools-4.1.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-trajectory-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-turtlesim-1.4.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-uncrustify-vendor-2.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdf-2.6.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdfdom-3.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdfdom-headers-1.0.6-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-visualization-msgs-4.2.4-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-zstd-vendor-0.15.13-np126py311h65a17ee_5.conda
+      - conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros2-distro-mutex-0.6.0-humble_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.54-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.16-h7e2c5d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sip-6.12.0-py311h2e0833b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-hd4fb6f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.14.1-h9d9cc24_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.50.2-h1b15455_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.1.0-hf6e3e71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h5ad3122_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.74.0-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-16.0.0-py311ha879c10_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/utfcpp-4.0.6-h01cc221_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-9.3.1-qt_py311h502ffb0_213.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-base-9.3.1-qt_py311h71e73b3_213.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.3.1-qt_py311h502ffb0_213.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-cursor-0.1.5-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.45-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.6-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.6-h86ecc28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.1-h2dbfc1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.1-h2dbfc1b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarl-1.20.1-py311h58d527c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
+  md5: 6168d71addc746e8f2b8d57dfd2edcea
+  depends:
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23712
+  timestamp: 1650670790230
+- conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.1-unix_0.conda
+  sha256: 824a7349bbb2ef8014077ddcfd418065a0a4de873ada1bd1b8826e20bed18c15
+  md5: eeb18017386c92765ad8ffa986c3f4ce
+  depends:
+  - __unix
+  - hicolor-icon-theme
+  - librsvg
+  license: LGPL-3.0-or-later OR CC-BY-SA-3.0
+  license_family: LGPL
+  size: 619606
+  timestamp: 1750236493212
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
+  sha256: 7842ddc678e77868ba7b92a726b437575b23aaec293bca0d40826f1026d90e27
+  md5: 18fd895e0e775622906cdabfc3cf0fb4
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  size: 19750
+  timestamp: 1741775303303
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.13-py311h2dc5d0c_0.conda
+  sha256: da6e5dbe388dc5584ec36c00914416acb73979fde9335f47cb00a99eabc64560
+  md5: 477dd55f95cacfae8e428bea0c4a9de4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=13
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 1008154
+  timestamp: 1749924115891
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.12.13-py311h58d527c_0.conda
+  sha256: 666fd9de5b1341539cbe1ce365e56bde8e90ce14238fe8bcf7e4aceae2f701e0
+  md5: 87fd80ea397eec29ed0721a97024dd95
+  depends:
+  - aiohappyeyeballs >=2.5.0
+  - aiosignal >=1.1.2
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - libgcc >=13
+  - multidict >=4.5,<7.0
+  - propcache >=0.2.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yarl >=1.17.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  size: 1003022
+  timestamp: 1749923669985
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.2-pyhd8ed1ab_0.conda
+  sha256: 7de8ced1918bbdadecf8e1c1c68237fe5709c097bd9e0d254f4cad118f4345d0
+  md5: 1a3981115a398535dbe3f6d5faae3d36
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13229
+  timestamp: 1734342253061
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
+  sha256: b9214bc17e89bf2b691fad50d952b7f029f6148f4ac4fe7c60c08f093efdf745
+  md5: 76df83c2a9035c54df5d04ff81bcc02d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 566531
+  timestamp: 1744668655747
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.14-h86ecc28_0.conda
+  sha256: 0aa836f6dd9132f243436898ed8024f408910f65220bafbfc95f71ab829bb395
+  md5: a696b24c1b473ecc4774bcb5a6ac6337
+  depends:
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  size: 595290
+  timestamp: 1744668754404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  md5: 346722a0be40f6edc53f12640d301338
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2706396
+  timestamp: 1718551242397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+  sha256: ac438ce5d3d3673a9188b535fc7cda413b479f0d52536aeeac1bd82faa656ea0
+  md5: cc744ac4efe5bcaa8cca51ff5b850df0
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 3250813
+  timestamp: 1718551360260
+- conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.6.2-pyhd8ed1ab_0.conda
+  sha256: 66ffcf30550e0788d16090e4b4e8835290b15439bb454b0e217176a09dc1d500
+  md5: eb9d4263271ca287d2e0cf5a86da2d3a
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 42164
+  timestamp: 1743726091226
+- conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+  sha256: c9022ee34f756847f48907472514da3395a8c0549679cfd2a1b4f6833dd6298c
+  md5: 5546062a59566def2fa6482acf531841
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3535704
+  timestamp: 1725086969417
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+  sha256: e791fd005b413d1fc7aa7f84d8c83343c64b53ab02e7bd410cb1f2f61789baf9
+  md5: 553a8f53d6d599fa15dcbdd95c3c8cee
+  depends:
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3476475
+  timestamp: 1725087034438
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+  sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
+  md5: 6b889f174df1e0f816276ae69281af4d
+  depends:
+  - at-spi2-core >=2.40.0,<2.41.0a0
+  - atk-1.0 >=2.36.0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.1,<3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 339899
+  timestamp: 1619122953439
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
+  sha256: c2c2c998d49c061e390537f929e77ce6b023ef22b51a0f55692d6df7327f3358
+  md5: 4ea9d4634f3b054549be5e414291801e
+  depends:
+  - at-spi2-core >=2.40.0,<2.41.0a0
+  - atk-1.0 >=2.36.0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.1,<3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 322172
+  timestamp: 1619123713021
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+  sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
+  md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.3,<3.0a0
+  - xorg-libx11
+  - xorg-libxi
+  - xorg-libxtst
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 658390
+  timestamp: 1625848454791
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
+  sha256: cd48de9674a20133e70a643476accc1a63360c921ab49477638364877937a40d
+  md5: a12602a94ee402b57063ef74e82016c0
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.3,<3.0a0
+  - xorg-libx11
+  - xorg-libxi
+  - xorg-libxtst
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 622407
+  timestamp: 1625848355776
+- conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+  sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
+  md5: f730d54ba9cd543666d7220c9f7ed563
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 355900
+  timestamp: 1713896169874
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
+  sha256: 69f70048a1a915be7b8ad5d2cbb7bf020baa989b5506e45a676ef4ef5106c4f0
+  md5: 9308557e2328f944bd5809c5630761af
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 358327
+  timestamp: 1713898303194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+  sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
+  md5: d9c69a24ad678ffce24c6543a0176b00
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 71042
+  timestamp: 1660065501192
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+  sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
+  md5: 1ef6c06fec1b6f5ee99ffe2152e53568
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 74992
+  timestamp: 1660065534958
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
+  sha256: 99c53ffbcb5dc58084faf18587b215f9ac8ced36bbfb55fa807c00967e419019
+  md5: a10d11958cadc13fdb43df75f8b1903f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 57181
+  timestamp: 1741918625732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_5.conda
+  sha256: 2f2a9b6d1cb24eb1df0bd820f35e089fbecab15d8952075b53dc931d89bf98cb
+  md5: 4846404183ea94fd6652e9fb6ac5e16f
+  depends:
+  - binutils_impl_linux-64 >=2.43,<2.44.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 35281
+  timestamp: 1749852911395
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_5.conda
+  sha256: bf15ac71af26196e3e0517f9ce5bd4bc624ca36a6f4e49df264a46555c599669
+  md5: 76b732e8c4af11139b7d78f4d4eca438
+  depends:
+  - binutils_impl_linux-aarch64 >=2.43,<2.44.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 35210
+  timestamp: 1749852871702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_5.conda
+  sha256: 27ae158d415ff2942214b32ac7952e642f0f4c2a45ab683691e2a9a9159f868c
+  md5: 18852d82df8e5737e320a8731ace51b9
+  depends:
+  - ld_impl_linux-64 2.43 h712a8e2_5
+  - sysroot_linux-64
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6376971
+  timestamp: 1749852878015
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_5.conda
+  sha256: 9155d9abba47a299bc13493a139c52bd70bbc44ba45d86b66887828595423158
+  md5: d908952b3f0f997965ee7891413ba8de
+  depends:
+  - ld_impl_linux-aarch64 2.43 h80caac9_5
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6263705
+  timestamp: 1749852844543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_5.conda
+  sha256: fccbb1974d5557cd5bd4dfccc13c0d15ca198c6a45c2124341dea8c952538512
+  md5: 327ef163ac88b57833c1c1a20a9e7e0d
+  depends:
+  - binutils_impl_linux-64 2.43 h4bf12b8_5
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 36038
+  timestamp: 1749852914153
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_5.conda
+  sha256: 22cca1af28fe2fd1d188186f369fed337c2a1e41668bbfbf6922611321de412f
+  md5: 3b4b0e942da0dc1d40b3bf02b5ae9f25
+  depends:
+  - binutils_impl_linux-aarch64 2.43 h4c662bb_5
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 36037
+  timestamp: 1749852874384
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+  sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
+  md5: 2c2fae981fd2afd00812c92ac47d023d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 48427
+  timestamp: 1733513201413
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/blosc-1.21.6-hb4dfabd_1.conda
+  sha256: f1e408fc32e1fda8dee9c3fceee5650fd622526e4dc6fa1f1926f497b5508d13
+  md5: 2cbbd6264ad58887c40aab37f2abdaba
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 36414
+  timestamp: 1733513501944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
+  sha256: c969baaa5d7a21afb5ed4b8dd830f82b78e425caaa13d717766ed07a61630bec
+  md5: 5d08a0ac29e6a5a984817584775d4131
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.1.0 hb9d3cd8_3
+  - libbrotlidec 1.1.0 hb9d3cd8_3
+  - libbrotlienc 1.1.0 hb9d3cd8_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19810
+  timestamp: 1749230148642
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.1.0-h86ecc28_3.conda
+  sha256: 71291a171728400f7af6be1a4ffaf805cff3684ae621ae5f792171235c7171f1
+  md5: 725908554f2bf8f68502bbade3ea3489
+  depends:
+  - brotli-bin 1.1.0 h86ecc28_3
+  - libbrotlidec 1.1.0 h86ecc28_3
+  - libbrotlienc 1.1.0 h86ecc28_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19937
+  timestamp: 1749230328962
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
+  sha256: ab74fa8c3d1ca0a055226be89e99d6798c65053e2d2d3c6cb380c574972cd4a7
+  md5: 58178ef8ba927229fba6d84abf62c108
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.1.0 hb9d3cd8_3
+  - libbrotlienc 1.1.0 hb9d3cd8_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19390
+  timestamp: 1749230137037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.1.0-h86ecc28_3.conda
+  sha256: 0ccc233f83fdaef013b1dfa7b0501b7301abe1d5e38a0cac6eb3742d5ae46567
+  md5: e06eec5d869ddde3abbb8c9784425106
+  depends:
+  - libbrotlidec 1.1.0 h86ecc28_3
+  - libbrotlienc 1.1.0 h86ecc28_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19394
+  timestamp: 1749230315332
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-3.25-hbd00459_4.conda
+  sha256: 969d9fea8da3b3c3ace1d1cb270c8938886ca7feb61d4b3f394abfbfbe82ea29
+  md5: 14f04d8353df4f2134b218d87435f33a
+  depends:
+  - bullet-cpp 3.25 h7db5c69_4
+  - numpy
+  - pybullet 3.25 py311h2ed89a0_4
+  - python
+  license: Zlib
+  size: 11721
+  timestamp: 1747516565520
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-3.25-h58b41f2_4.conda
+  sha256: fdacd04e3d5d96f6b793a225fd962e28839cdf4f0c83542f3d4844d7c566da6e
+  md5: 7db22593b769ee6ac6243052bf413f3e
+  depends:
+  - bullet-cpp 3.25 py311h848c333_4
+  - numpy
+  - pybullet 3.25 py311h7b00dee_4
+  - python
+  license: Zlib
+  size: 11746
+  timestamp: 1747516772423
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-h7db5c69_4.conda
+  sha256: de47887981cec9385ea780a02d539e6446f9393af91a1eeb27cf884b290b9877
+  md5: 3c1389f538dd361396dc8566ef89d982
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python_abi 3.11.* *_cp311
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: Zlib
+  size: 43026158
+  timestamp: 1747516092494
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bullet-cpp-3.25-py311h848c333_4.conda
+  sha256: 730bab690df5110f8d15f94d7ed22e84ed42e8af5d4bbdd5f00f7c086f549798
+  md5: ca92652e5617727388737a9a554798a2
+  depends:
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: Zlib
+  size: 42006090
+  timestamp: 1747516217642
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
+  md5: 56398c28220513b9ea13d7b450acfb20
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 189884
+  timestamp: 1720974504976
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
+  sha256: f8003bef369f57396593ccd03d08a8e21966157269426f71e943f96e4b579aeb
+  md5: f7f0d6cc2dc986d42ac2689ec88192be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 206884
+  timestamp: 1744127994291
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.5-h86ecc28_0.conda
+  sha256: ccae98c665d86723993d4cb0b456bd23804af5b0645052c09a31c9634eebc8df
+  md5: 5deaa903d46d62a1f8077ad359c3062e
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 215950
+  timestamp: 1744127972012
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.10.0-h2b85faf_0.conda
+  sha256: 70be54bfe92b72794f664ad95b6fcef74d508710a9b2d790bc9c69f5a40239c3
+  md5: 9256b7e5e900a1b98aedc8d6ffe91bec
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-64 13.*
+  license: BSD-3-Clause
+  size: 6667
+  timestamp: 1751115555092
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.10.0-h6561dab_0.conda
+  sha256: d33f1f8373455bea2cbedbbbb1534c1123a8e1bba95ca4bf655990017533dcdf
+  md5: 53f1416f2e64d87fbac3a398f8e226e3
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-aarch64 13.*
+  license: BSD-3-Clause
+  size: 6732
+  timestamp: 1751115561791
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
+  sha256: 7cfec9804c84844ea544d98bda1d9121672b66ff7149141b8415ca42dfcd44f6
+  md5: 72525f07d72806e3b639ad4504c30ce5
+  depends:
+  - __unix
+  license: ISC
+  size: 151069
+  timestamp: 1749990087500
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+  sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
+  md5: 09262e66b19567aff4f592fb53b28760
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.44.2,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  size: 978114
+  timestamp: 1741554591855
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h83712da_0.conda
+  sha256: 37cfff940d2d02259afdab75eb2dbac42cf830adadee78d3733d160a1de2cc66
+  md5: cd55953a67ec727db5dc32b167201aa6
+  depends:
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.44.2,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  size: 966667
+  timestamp: 1741554768968
+- conda: https://conda.anaconda.org/conda-forge/noarch/catkin_pkg-1.0.0-pyhd8ed1ab_1.conda
+  sha256: f210ad987595a6ea0bf37ff600a820627e9f7a5eba2e6b2db02f714e925e8624
+  md5: 016600de0d8b1a8c5ccc99845f51f9da
+  depends:
+  - docutils
+  - pyparsing >=1.5.7
+  - python >=3.9
+  - python-dateutil
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 53393
+  timestamp: 1734127327150
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 302115
+  timestamp: 1725560701719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.17.1-py311h14e8bb7_0.conda
+  sha256: 3d220020c9782ebd4f23cd0a6148b419e4397590ee414e6e69b9be810c57d2ca
+  md5: 616d65d1eea809af7e2b5f7ea36350fc
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 319122
+  timestamp: 1725562148568
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-20.1.7-default_h1df26ce_0.conda
+  sha256: 3bc17a388920bed0e543d84727c4c13a9a1f40d55567ee03bbbce6737c871565
+  md5: 8926fbb152c929db4d40d7665464846a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - clang-format-20 20.1.7 default_h1df26ce_0
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 24501
+  timestamp: 1749876682063
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-20.1.7-default_h7d4303a_0.conda
+  sha256: 3d4f34e4af95f9b0adc97354c36716b11157222fcc593d1e7b8b4c956db14f67
+  md5: 4e1dade02d7a36344035a0dc877b8336
+  depends:
+  - clang-format-20 20.1.7 default_h7d4303a_0
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 24639
+  timestamp: 1749877433281
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-20-20.1.7-default_h1df26ce_0.conda
+  sha256: 0a34db888eed20f550d3b9382d8b51ea7b2987fb479b2eda4c6a409d5a538660
+  md5: 1c99f503e3a52abf225cfd517c718a1b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 68266
+  timestamp: 1749876630650
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-20-20.1.7-default_h7d4303a_0.conda
+  sha256: c2ec487b4039b0561204ef53c8672fbcbf23fb336b99ef9ac3c108d1565ee349
+  md5: ffba104bc65e388a52f66920d177194d
+  depends:
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 68929
+  timestamp: 1749877392799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.26.4-hcfe8598_0.conda
+  sha256: 37533b572a676017704c989c392998c344e889010786d6555dccdfc524a8e238
+  md5: 1714cf0f0facaeb609a0846e4270aff2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - expat
+  - libcurl >=8.1.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - rhash <=1.4.3
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16343060
+  timestamp: 1684460894541
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.26.4-hef020d8_0.conda
+  sha256: bd53a3d5255ff106f6aea125217731ae062f3e1017b743069ccde351ed6a0929
+  md5: 8198d47d180d775639809145e31870a4
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - expat
+  - libcurl >=8.1.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.3,<7.0a0
+  - rhash <=1.4.3
+  - xz >=5.2.6,<6.0a0
+  - zlib
+  - zstd >=1.5.2,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16028057
+  timestamp: 1684460708828
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-argcomplete-0.3.3-pyhd8ed1ab_1.conda
+  sha256: 05ccb85cad9ca58be9dcb74225f6180a68907a6ab0c990e3940f4decc5bb2280
+  md5: bde6042a1b40a2d4021e1becbe8dd84f
+  depends:
+  - argcomplete
+  - colcon-core
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18692
+  timestamp: 1735452378252
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-bash-0.5.0-pyhd8ed1ab_1.conda
+  sha256: 4a1258c9743f4e29d666993c3aa29aaf5a310a77f5334f98b81f1c80c2a46fa7
+  md5: abcd9e9bc122d03f86d364ccb15957c7
+  depends:
+  - colcon-core >=0.4.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 19001
+  timestamp: 1735646679519
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cd-0.1.1-pyhd8ed1ab_1.conda
+  sha256: 4cbac86d8c2c62293586664b3ccb3371bb51b671a8ee607adaadf78a9a745f92
+  md5: 872e61a33caebff21a695ea1f886f3bf
+  depends:
+  - colcon-core >=0.4.1
+  - colcon-package-information
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16858
+  timestamp: 1735513271475
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-cmake-0.2.28-pyhd8ed1ab_0.conda
+  sha256: 7687dfa89ba61bbc4cdf7dab40fbf9b8ff2cf0d58ec1b57a8a54c91b2858b47e
+  md5: 9de79776547780dd4a4e095d3bc3044c
+  depends:
+  - colcon-core
+  - colcon-library-path
+  - colcon-test-result >=0.3.3
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 25388
+  timestamp: 1696469433425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/colcon-common-extensions-0.3.0-py311h38be061_2.conda
+  sha256: 7b8b856aab89a5c532aad7c9a47c785346f43aa2bf2f4bd0e6a7b55521f6a428
+  md5: 05e394f53319e5d665842ac3eb951675
+  depends:
+  - colcon-argcomplete
+  - colcon-bash
+  - colcon-cd
+  - colcon-cmake
+  - colcon-core
+  - colcon-defaults
+  - colcon-devtools
+  - colcon-library-path
+  - colcon-metadata
+  - colcon-output
+  - colcon-package-information
+  - colcon-package-selection
+  - colcon-parallel-executor
+  - colcon-powershell
+  - colcon-python-setup-py
+  - colcon-recursive-crawl
+  - colcon-ros
+  - colcon-test-result
+  - colcon-zsh
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12467
+  timestamp: 1726305108334
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/colcon-common-extensions-0.3.0-py311hec3470c_2.conda
+  sha256: dd385a28608c88c4a735c888af406bd678c8875f18abb8e07385ebc8b91e42a0
+  md5: 97b892f6a75e198c3c3d77d6d46f38ea
+  depends:
+  - colcon-argcomplete
+  - colcon-bash
+  - colcon-cd
+  - colcon-cmake
+  - colcon-core
+  - colcon-defaults
+  - colcon-devtools
+  - colcon-library-path
+  - colcon-metadata
+  - colcon-output
+  - colcon-package-information
+  - colcon-package-selection
+  - colcon-parallel-executor
+  - colcon-powershell
+  - colcon-python-setup-py
+  - colcon-recursive-crawl
+  - colcon-ros
+  - colcon-test-result
+  - colcon-zsh
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13032
+  timestamp: 1726305296120
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-core-0.19.0-pyhd8ed1ab_1.conda
+  sha256: 565322c13eb28db869d8de16f5ae14caebb2b58f76c11ab8eaddeb5eaa2e50e9
+  md5: d7c6db7125d9f78ec34451f4b4d471cb
+  depends:
+  - coloredlogs
+  - distlib
+  - empy
+  - pytest
+  - pytest-cov
+  - pytest-repeat
+  - pytest-rerunfailures
+  - python >=3.9
+  - setuptools >=30.3.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 88696
+  timestamp: 1742163247059
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-defaults-0.2.8-pyhd8ed1ab_0.conda
+  sha256: 1ed9478917110335a37c6f37fc0542cdf623a99c93032c938fb395f607a433e3
+  md5: 9280937fc017d85b61b797f14370766f
+  depends:
+  - colcon-core >=0.2.0
+  - python >=3.5
+  - pyyaml
+  license: Apache-2.0
+  license_family: APACHE
+  size: 14626
+  timestamp: 1675322151128
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-devtools-0.3.0-pyhd8ed1ab_0.conda
+  sha256: a1e3266159b26e0de623e7158b6554aa5a5e2a976060a59a8dc007dcc4a4c0a3
+  md5: 6179c56610341089e237027b316b520c
+  depends:
+  - colcon-core
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 14347
+  timestamp: 1710399090247
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-library-path-0.2.1-py_0.tar.bz2
+  sha256: d70d1be5690c2680d1efce0862ef3fdd9332676d98fcc7a86caf1daab2336ba2
+  md5: 321895b5868349cc477f47c91ac870e9
+  depends:
+  - colcon-core
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 10753
+  timestamp: 1570998873901
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-metadata-0.2.5-py_0.tar.bz2
+  sha256: b5132ecbd56edae56c328a4306e368dca1f92def2184c82e5133636d7c009237
+  md5: 60466c2c5d2a6bc78c3badaaf304bcb7
+  depends:
+  - colcon-core
+  - python >=3.5
+  - pyyaml
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17805
+  timestamp: 1597041738215
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-output-0.2.13-pyhd8ed1ab_0.conda
+  sha256: ce2802f9c76f4502d17ff47f76f634449a1ae10fded0bed6a65c05d35ccafb33
+  md5: d0294b947e6256444f31979612468bba
+  depends:
+  - colcon-core >=0.3.8
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16174
+  timestamp: 1676526311561
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-information-0.4.0-pyhd8ed1ab_0.conda
+  sha256: fcea11b23e09e885f7989dfb1468c34985060bf9c5f1ec6d8e59af3f8256ce92
+  md5: ed85497b62f88dd3c018272edc81d8b5
+  depends:
+  - colcon-core
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18063
+  timestamp: 1710399124724
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-package-selection-0.2.10-py_0.tar.bz2
+  sha256: 75aa0932d21829bb74c8ec8877b4dc82d5cbcfac79ae3ca8f2ef0128d2962e99
+  md5: 096e1c0408ce1cf62fcb2c204048c4ba
+  depends:
+  - colcon-core >=0.3.19
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16036
+  timestamp: 1602007048566
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-parallel-executor-0.3.0-pyhd8ed1ab_1.conda
+  sha256: 71c8c02c5151d04a275e9c39eaf77350ec67a33763992262e3da8c9cf6076236
+  md5: 1b7700d01109498cbd5c3507f8bf8750
+  depends:
+  - colcon-core >=0.3.15
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 14980
+  timestamp: 1736253057571
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-pkg-config-0.1.0-py_0.tar.bz2
+  sha256: c8c6baf7ba174c908d501c6df577c140de73f46aadea09a6b3aaf405406e3b5a
+  md5: 434ecb5d163df485879081aedebd59bf
+  depends:
+  - colcon-core
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 10397
+  timestamp: 1571038968482
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-powershell-0.4.0-pyhd8ed1ab_0.conda
+  sha256: b54f4da2b2826a9b40bf879c88f00f716ed15f05c072b04de666a4b2181f4bcf
+  md5: 80c4494a26b9e887c03a46491c98e217
+  depends:
+  - colcon-core >=0.3.18
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16734
+  timestamp: 1696619534089
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-python-setup-py-0.2.9-pyhff2d567_0.conda
+  sha256: 75d6347be8aed680b876b060b61161bd0d165c5f89968a659d74343d4685d19b
+  md5: 89efe9bf1e956c011984b7729b566026
+  depends:
+  - colcon-core >=0.6.1
+  - python >=3.6
+  - setuptools
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15884
+  timestamp: 1728887930380
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-recursive-crawl-0.2.3-pyhd8ed1ab_0.conda
+  sha256: 8aede8793a64695cf65f37633ede04c125db71d13abc2c8fb70b44fbc48d3794
+  md5: 0e15eecc695ef5a4508ffe3e438f1466
+  depends:
+  - colcon-core >=0.2.0
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13254
+  timestamp: 1696534627965
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-ros-0.5.0-pyhd8ed1ab_0.conda
+  sha256: 7c018dd7074de3b3bac375718cd43ff4677ef18f8ab81c3a75bed4eb646e280e
+  md5: 7ba348bf6258968e8f514cd25c207933
+  depends:
+  - catkin_pkg >=0.4.14
+  - colcon-cmake >=0.2.6
+  - colcon-core >=0.7.0
+  - colcon-pkg-config
+  - colcon-python-setup-py >=0.2.4
+  - colcon-recursive-crawl
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 23852
+  timestamp: 1719301582281
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-test-result-0.3.8-py_0.tar.bz2
+  sha256: 78cb733da257344b80ab814f879de3612b67178a45352722c87a82f6f2fe1d81
+  md5: 801f8de0cc53c86cd54f9f81392fa7b8
+  depends:
+  - colcon-core
+  - python >=3.5
+  license: Apache-2.0
+  license_family: APACHE
+  size: 14697
+  timestamp: 1571039078605
+- conda: https://conda.anaconda.org/conda-forge/noarch/colcon-zsh-0.5.0-pyhd8ed1ab_1.conda
+  sha256: 0f089c2ee902d7d43b75f22af74af2dd914546d81e7380c097e31a206c42984e
+  md5: a274fdd9d63e809b4fdcaee36a8bc42c
+  depends:
+  - colcon-core >=0.4.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 18905
+  timestamp: 1735357634338
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+  sha256: 8021c76eeadbdd5784b881b165242db9449783e12ce26d6234060026fd6a8680
+  md5: b866ff7007b934d564961066c8195983
+  depends:
+  - humanfriendly >=9.1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 43758
+  timestamp: 1733928076798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.10.0-ha770c72_0.conda
+  sha256: 17661cca0b6b70156a5d4a639c926bff0106576b5af5c8cab7afd9cd3cfa287b
+  md5: 993ae32cac4879279af74ba12aa0979c
+  depends:
+  - c-compiler 1.10.0 h2b85faf_0
+  - cxx-compiler 1.10.0 h1a2810e_0
+  - fortran-compiler 1.10.0 h36df796_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7452
+  timestamp: 1751115555727
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compilers-1.10.0-h8af1aa0_0.conda
+  sha256: 3dac4aba396991809adbf74b7b467d4cf1034f1963e65ebf6efb6878e3280bd0
+  md5: 5dde5330d359cfa0747d4190fa05acae
+  depends:
+  - c-compiler 1.10.0 h6561dab_0
+  - cxx-compiler 1.10.0 heb6c788_0
+  - fortran-compiler 1.10.0 h25a59a9_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7504
+  timestamp: 1751115562750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/console_bridge-1.0.2-h924138e_1.tar.bz2
+  sha256: 29caeda123ea705e68de46dc3b86065ec78f5b44d7ae69b320cc57e136d2d9d7
+  md5: e891b2b856a57d2b2ddb9ed366e3f2ce
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18460
+  timestamp: 1648912649612
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/console_bridge-1.0.2-hdd96247_1.tar.bz2
+  sha256: 3155a52cb046da65ba7afc8f9b4e6c54881fe511a56b3517b8b4fbd42607b088
+  md5: 87cedc27ed44d7bda9cb29a6294dfe04
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18484
+  timestamp: 1648912662150
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py311hd18a35c_0.conda
+  sha256: 92ec3244ee0b424612025742a73d4728ded5bf6a358301bd005f67e74fec0b21
+  md5: f8e440efa026c394461a45a46cea49fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278355
+  timestamp: 1744743253299
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.3.2-py311hc07b1fb_0.conda
+  sha256: fc3522c4d7924bd75fed7be2ecd77417541a465581d7d5c28fa4de97463c46ce
+  md5: ad098eab8ae35cde45f317ad095fdf65
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 290096
+  timestamp: 1744743407413
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py311h2dc5d0c_0.conda
+  sha256: 09245391f91135f4eea87d64107e82d4fb4b7d4fbd6596ea6cc126645191220c
+  md5: f524bd18889f169f2fa8dc70df1c53c3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 383591
+  timestamp: 1749833491301
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.9.1-py311ha09ea12_0.conda
+  sha256: f65813a7a97a6ba23939c815cbc1d4d19b44def6535670099063b95299a2596c
+  md5: 943d250e9e790e53f4ec59bff0acd99a
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 385143
+  timestamp: 1749834698750
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cppcheck-2.17.1-py311hca438b8_0.conda
+  sha256: 857055e9b708cdfdb99e1e2fe073af942146e8436dc49edbdec1756df0a3b44c
+  md5: 5a1c1a7721bf15d65cc35e4e0310a030
+  depends:
+  - pygments
+  - python
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - tinyxml2 >=10.0.0,<10.1.0a0
+  - pcre >=8.45,<9.0a0
+  - python_abi 3.11.* *_cp311
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2892866
+  timestamp: 1744009731097
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cppcheck-2.17.1-py311h06690bc_0.conda
+  sha256: a3aecedb187642296e68b7efc9775321e71b63cec4f874cebfb10288b3ab48a4
+  md5: fc4d99bc204a0f04de832be09987a0b0
+  depends:
+  - pygments
+  - python
+  - python 3.11.* *_cpython
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - pcre >=8.45,<9.0a0
+  - tinyxml2 >=10.0.0,<10.1.0a0
+  - python_abi 3.11.* *_cp311
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2803871
+  timestamp: 1744009729979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py311hafd3f86_0.conda
+  sha256: 0832d1aff2f6606824a89aed2427da26bda9914b6d2ff34ec643f560f4560547
+  md5: 0cfa6cebbf4b3c8f16be9fba587d990a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.12
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1662736
+  timestamp: 1749538948414
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-45.0.4-py311h4047cc9_0.conda
+  sha256: f2b6371bc4f4d5f753888849940300477424881c854eab81559ebbe5f01dd925
+  md5: 7e8009561ad14946f637910dbc51f932
+  depends:
+  - cffi >=1.12
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1642339
+  timestamp: 1749538780383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.10.0-h1a2810e_0.conda
+  sha256: 88ff4a72ad70a3b9a20a0296e395c0caaa6dc0a0e46a752aa683fb42be03facd
+  md5: 3cd322edac3d40904ff07355a8be8086
+  depends:
+  - c-compiler 1.10.0 h2b85faf_0
+  - gxx
+  - gxx_linux-64 13.*
+  license: BSD-3-Clause
+  size: 6633
+  timestamp: 1751115555450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.10.0-heb6c788_0.conda
+  sha256: d9545fc477c561d0d77e14d9bf683ed5af24b157517436aa0dd3bd85a5f13bd9
+  md5: 0ced8888a4d506775eec668a2ce93623
+  depends:
+  - c-compiler 1.10.0 h6561dab_0
+  - gxx
+  - gxx_linux-aarch64 13.*
+  license: BSD-3-Clause
+  size: 6705
+  timestamp: 1751115562352
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
+  md5: 44600c4667a319d67dbe0681fc0bc833
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13399
+  timestamp: 1733332563512
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
+  sha256: ee09ad7610c12c7008262d713416d0b58bf365bc38584dce48950025850bdf3f
+  md5: cae723309a49399d2949362f4ab5c9e4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libntlm >=1.8,<2.0a0
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 209774
+  timestamp: 1750239039316
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
+  sha256: 87b603b76b05e9be749a2616582bfb907e06e7851285bdd78f9ddaaa732d7bc7
+  md5: b6d06b46e791add99cc39fbbc34530d5
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libntlm
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  size: 227295
+  timestamp: 1750239141751
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+  sha256: 33fe66d025cf5bac7745196d1a3dd7a437abcf2dbce66043e9745218169f7e17
+  md5: 6e5a87182d66b2d1328a96b61ca43a62
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 347363
+  timestamp: 1685696690003
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
+  sha256: 3b988146a50e165f0fa4e839545c679af88e4782ec284cc7b6d07dd226d6a068
+  md5: 679616eb5ad4e521c83da4650860aba7
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libexpat >=2.7.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.84.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 437860
+  timestamp: 1747855126005
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.16.2-heda779d_0.conda
+  sha256: 5c9166bbbe1ea7d0685a1549aad4ea887b1eb3a07e752389f86b185ef8eac99a
+  md5: 9203b74bb1f3fa0d6f308094b3b44c1e
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - libexpat >=2.7.0,<3.0a0
+  - libglib >=2.84.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 469781
+  timestamp: 1747855172617
+- conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+  sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
+  md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 274151
+  timestamp: 1733238487461
+- conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 41773
+  timestamp: 1734729953882
+- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+  sha256: fa5966bb1718bbf6967a85075e30e4547901410cc7cb7b16daf68942e9a94823
+  md5: 24c1ca34138ee57de72a943237cde4cc
+  depends:
+  - python >=3.9
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 402700
+  timestamp: 1733217860944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
+  sha256: 1bcc132fbcc13f9ad69da7aa87f60ea41de7ed4d09f3a00ff6e0e70e1c690bc2
+  md5: bfd56492d8346d669010eccafe0ba058
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 69544
+  timestamp: 1739569648873
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/double-conversion-3.3.1-h5ad3122_0.conda
+  sha256: 9a2282445e8ee2da6253490c896bc3be80f07550564a6db5f4920aa3ae390021
+  md5: 399959d889e1a73fc99f12ce480e77e1
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67140
+  timestamp: 1739571636249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+  sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
+  md5: b1b879d6d093f55dd40d58b5eb2f0699
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1088433
+  timestamp: 1690272126173
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+  sha256: f9c763805938ebaa43183b07caadce8eb3e1af8c21df8792f2793c3dd5210b4e
+  md5: 0057b28f7ed26d80bd2277a128f324b2
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1090421
+  timestamp: 1690273745233
+- conda: https://conda.anaconda.org/conda-forge/noarch/empy-3.3.4-pyh9f0ad1d_1.tar.bz2
+  sha256: 75e04755df8d8db7a7711dddaf68963c11258b755c9c24565bfefa493ee383e3
+  md5: e4be10fd1a907b223da5be93f06709d2
+  depends:
+  - python
+  license: LGPL-2.1
+  license_family: GPL
+  size: 40210
+  timestamp: 1586444722817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
+  sha256: 1e58ee2ed0f4699be202f23d49b9644b499836230da7dd5b2f63e6766acff89e
+  md5: a089d06164afd2d511347d3f87214e0b
+  depends:
+  - libgcc-ng >=10.3.0
+  license: MIT
+  license_family: MIT
+  size: 1440699
+  timestamp: 1648505042260
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-h4e544f5_1.tar.bz2
+  sha256: 2cdd3965353b24f49bd8d4aafaaf282968509dc600350c25d0d29355990af834
+  md5: e3000ef63f6250283a6ca13d38e3e8be
+  depends:
+  - libgcc-ng >=10.3.0
+  license: MIT
+  license_family: MIT
+  size: 1455489
+  timestamp: 1648505885929
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+  sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
+  md5: 72e42d28960d875c7654614f8b50939a
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  size: 21284
+  timestamp: 1746947398083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.7.0-h5888daf_0.conda
+  sha256: dd5530ddddca93b17318838b97a2c9d7694fa4d57fc676cf0d06da649085e57a
+  md5: d6845ae4dea52a2f90178bf1829a21f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat 2.7.0 h5888daf_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 140050
+  timestamp: 1743431809745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.7.0-h5ad3122_0.conda
+  sha256: 3eb41c357970b981ab5969ba38441025ae41011c228b33de7fc3ea90e5278b8a
+  md5: c22e14e241ade3d3a74c0409c3d582a2
+  depends:
+  - libexpat 2.7.0 h5ad3122_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 132849
+  timestamp: 1743432014146
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hb7c51ca_708.conda
+  sha256: 9de277f47685a99e4e727c23e450a285fc4b21cd3aacc1984c7be3bc978cf830
+  md5: bedfd83c2dd635eafc8f51e8bdb6cf12
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=10.1.0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libopenvino >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-hetero-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-npu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-ir-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-onnx-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-paddle-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-pytorch-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libva >=2.22.0,<3.0a0
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.5.0,<2.5.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 10330479
+  timestamp: 1734898637153
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_h013846f_708.conda
+  sha256: 972128a81a17b99a733bb1d8c3a24ae180ef25f509c122155756e9d102bc178a
+  md5: b0ada890c592e54744241d845d5495fd
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=10.1.0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libopenvino >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-hetero-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-ir-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-onnx-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-paddle-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-pytorch-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.5.0,<2.5.1.0a0
+  - openssl >=3.4.0,<4.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9936620
+  timestamp: 1734898706334
+- conda: https://conda.anaconda.org/conda-forge/noarch/flake8-7.3.0-pyhd8ed1ab_0.conda
+  sha256: a32e511ea71a9667666935fd9f497f00bcc6ed0099ef04b9416ac24606854d58
+  md5: 04a55140685296b25b79ad942264c0ef
+  depends:
+  - mccabe >=0.7.0,<0.8.0
+  - pycodestyle >=2.14.0,<2.15.0
+  - pyflakes >=3.4.0,<3.5.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 111916
+  timestamp: 1750968083921
+- conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h783367e_4.conda
+  sha256: 7e6b9d30281562496c53067e01e6e84dcbb16f43273510454463351155a7c80e
+  md5: 6998a241450abd1cb9305f4608001870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - lz4-c >=1.10.0,<1.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1564105
+  timestamp: 1733524739597
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-ha858f50_4.conda
+  sha256: 36c85fdd874964a33ebf74057005cd61efc83ddc131eaa93db2a1697db6ce3d1
+  md5: 2a7ecb62846072fb1441be10b01c5187
+  depends:
+  - _openmp_mutex >=4.5
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - lz4-c >=1.10.0,<1.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1406578
+  timestamp: 1733524751840
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h07f6e7f_1.conda
+  sha256: f9eeb49752b250e035ed0ee957fd813f7d2212eccb814006bbf92b89711605b1
+  md5: fbbfeaa24a99c3da00c35334935b0d24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 197559
+  timestamp: 1743030768885
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-11.0.2-h97e1849_1.conda
+  sha256: b48bdc6aee20c333e4e5ad95d62eb8fb8f1fc3d89c99ef044f027d57ee99c21d
+  md5: 583fbe41c7f0dc4470f0d18c8223e9b0
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 195682
+  timestamp: 1743032080239
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
+  sha256: fe023bb8917c8a3138af86ef537b70c8c5d60c44f93946a87d1e8bb1a6634b55
+  md5: 112b71b6af28b47c624bcbeefeea685b
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 277832
+  timestamp: 1730284967179
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4102
+  timestamp: 1566932280397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py311h2dc5d0c_0.conda
+  sha256: f57df9d0573fa04b53afdaa5253bc4f1902357cca9265951f9d6ebe46567a40e
+  md5: dd3ef31d2bf022668f30859d5e11c83e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2919952
+  timestamp: 1749848724761
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.58.4-py311h58d527c_0.conda
+  sha256: b13fbf6b95c1c59bf41c011ff5bca7d2ac1cc58bef26a1f9b963364ec2d15793
+  md5: cfd413de095dae38de62e479be440ddd
+  depends:
+  - brotli
+  - libgcc >=13
+  - munkres
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2870745
+  timestamp: 1749848608791
+- conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.3-h5888daf_1.conda
+  sha256: 28d9fce64ee8b5e94350feb0829e054811678f9638039f78ddff8a8615c1b693
+  md5: 2a3316f47d7827afde5381ecd43b5e85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Zlib
+  size: 227132
+  timestamp: 1746246721660
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.3-h5ad3122_1.conda
+  sha256: eb4ba5713109333869069346f8a68ee5472d33fbfef19765608ac56e56ad11be
+  md5: f56a1c764fb72416280f786c80122dbd
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Zlib
+  size: 225684
+  timestamp: 1746248561179
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.10.0-h36df796_0.conda
+  sha256: 451852c7f5ef20344e966bdfd8dfe26021819257fe37a019d4e2655b1c5f6057
+  md5: e2d49a61c0ebc4ee2c7779d940f2f3e7
+  depends:
+  - binutils
+  - c-compiler 1.10.0 h2b85faf_0
+  - gfortran
+  - gfortran_linux-64 13.*
+  license: BSD-3-Clause
+  size: 6650
+  timestamp: 1751115555592
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fortran-compiler-1.10.0-h25a59a9_0.conda
+  sha256: 8fad69d5f93802cb067aac6515f055b1b5a9aafedd1688890d7c06aaf61074e3
+  md5: af57286cbeb70fc64a553e2a6694aac9
+  depends:
+  - binutils
+  - c-compiler 1.10.0 h6561dab_0
+  - gfortran
+  - gfortran_linux-aarch64 13.*
+  license: BSD-3-Clause
+  size: 6725
+  timestamp: 1751115562576
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+  sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
+  md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144010
+  timestamp: 1719014356708
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
+  md5: c6c65566e07fec709e1ea4bc95fc56e4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  size: 144992
+  timestamp: 1719014317113
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeimage-3.18.0-h3a85593_22.conda
+  sha256: 03ccff5d255eab7a1736de9eeb539fbb1333036fa5e37ea7c8ec428270067c99
+  md5: bbdf3d43d752b793ac81f27b28c49e2d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - imath >=3.1.12,<3.1.13.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libraw >=0.21.3,<0.22.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.1,<3.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  size: 467860
+  timestamp: 1729024045245
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeimage-3.18.0-h6cb32c8_22.conda
+  sha256: 0a0ed82992c87aa67604569d35b6180863ca21081e94739194e6adde3f92f84d
+  md5: f6891bd5c49b824889b065446edefe37
+  depends:
+  - imath >=3.1.12,<3.1.13.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libraw >=0.21.3,<0.22.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openexr >=3.3.1,<3.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: GPL-2.0-or-later OR GPL-3.0-or-later OR FreeImage
+  size: 453451
+  timestamp: 1729024016441
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
+  sha256: 7ef7d477c43c12a5b4cddcf048a83277414512d1116aba62ebadfa7056a7d84f
+  md5: 9ccd736d31e0c6e41f54e704e5312811
+  depends:
+  - libfreetype 2.13.3 ha770c72_1
+  - libfreetype6 2.13.3 h48d6fc4_1
+  license: GPL-2.0-only OR FTL
+  size: 172450
+  timestamp: 1745369996765
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.13.3-h8af1aa0_1.conda
+  sha256: 3b3ff45ac1fc880fbc8268477d29901a8fead32fb2241f98e4f2a1acffe6eea2
+  md5: 71c4cbe1b384a8e7b56993394a435343
+  depends:
+  - libfreetype 2.13.3 h8af1aa0_1
+  - libfreetype6 2.13.3 he93130f_1
+  license: GPL-2.0-only OR FTL
+  size: 172259
+  timestamp: 1745370055170
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+  sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
+  md5: ac7bc6a654f8f41b352b38f4051135f8
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  size: 114383
+  timestamp: 1604416621168
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+  sha256: bcb5a40f1aaf4ea8cda2fc6b2b12aa336403772121350281ce31fd2d9d3e214e
+  md5: f6c91a43eace6fb926a8730b3b9a8a50
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  size: 115689
+  timestamp: 1604417149643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.6.0-py311h62d540b_0.conda
+  sha256: fe83cad8aa17a6dd9c3e5625f2ed44343d057945a6b0fb6aabcb507ca1cf0d5d
+  md5: ad01dcb674e8792b626276999ab1825e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 113590
+  timestamp: 1746635675256
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.6.0-py311ha6a3852_0.conda
+  sha256: e686f067d039deae1acd53ae635eb9ca59dc289bc33973fd3d2ad71fd5b75b76
+  md5: eee1960fe628f5c365850fb25a2106d3
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 114383
+  timestamp: 1746635649081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.3.0-h9576a4e_2.conda
+  sha256: 300f077029e7626d69cc250a69acd6018c1fced3f5bf76adf37854f3370d2c45
+  md5: d92e51bf4b6bdbfe45e5884fb0755afe
+  depends:
+  - gcc_impl_linux-64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55246
+  timestamp: 1740240578937
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-13.3.0-h8a56e6e_2.conda
+  sha256: 9ed279e4cc830e1c155070e81ca50d5e4016442e0ba982dd92040c6d7670a9d3
+  md5: e29ca0749eb6d7492490523ac9216cbd
+  depends:
+  - gcc_impl_linux-aarch64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55416
+  timestamp: 1740241243780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.3.0-h1e990d8_2.conda
+  sha256: c3e9f243ea8292eecad78bb200d8f5b590e0f82bf7e7452a3a7c8df4eea6f774
+  md5: f46cf0acdcb6019397d37df1e407ab91
+  depends:
+  - binutils_impl_linux-64 >=2.40
+  - libgcc >=13.3.0
+  - libgcc-devel_linux-64 13.3.0 hc03c837_102
+  - libgomp >=13.3.0
+  - libsanitizer 13.3.0 he8ea267_2
+  - libstdcxx >=13.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 66770653
+  timestamp: 1740240400031
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-13.3.0-h80a1502_2.conda
+  sha256: 014409803f805d62318e4099e6374634fb79a0dc9923e2b12dcefe8488fee983
+  md5: 720bd2eb66aa3f3025606e5c166d579a
+  depends:
+  - binutils_impl_linux-aarch64 >=2.40
+  - libgcc >=13.3.0
+  - libgcc-devel_linux-aarch64 13.3.0 h0c07274_102
+  - libgomp >=13.3.0
+  - libsanitizer 13.3.0 ha58e236_2
+  - libstdcxx >=13.3.0
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 62397267
+  timestamp: 1740241109506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-13.3.0-h6f18a23_11.conda
+  sha256: b2533388ec510ef0fc95774f15fdfb89582623049494506ea27622333f90bc09
+  md5: 639ef869618e311eee4888fcb40747e2
+  depends:
+  - binutils_linux-64
+  - gcc_impl_linux-64 13.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32538
+  timestamp: 1748905867619
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-13.3.0-h1cd514b_11.conda
+  sha256: c4711fbcee1f01767e239e6908b102be6170e9c16a0c97507ed96f77b6e40011
+  md5: 17c8fb1462072371f083adc3207180f6
+  depends:
+  - binutils_linux-aarch64
+  - gcc_impl_linux-aarch64 13.3.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32471
+  timestamp: 1748905800282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
+  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 528149
+  timestamp: 1715782983957
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
+  sha256: 608f64aa9cf3085e91da8d417aa7680715130b4da73d8aabc50b19e29de697d2
+  md5: 332ed304e6d1c1333ccbdc0fdd722fe9
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 536613
+  timestamp: 1715784386033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.24.1-h5888daf_0.conda
+  sha256: 88db27c666e1f8515174bf622a3e2ad983c94d69e3a23925089e476b9b06ad00
+  md5: c63e7590d4d6f4c85721040ed8b12888
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext-tools 0.24.1 h5888daf_0
+  - libasprintf 0.24.1 h8e693c7_0
+  - libasprintf-devel 0.24.1 h8e693c7_0
+  - libgcc >=13
+  - libgettextpo 0.24.1 h5888daf_0
+  - libgettextpo-devel 0.24.1 h5888daf_0
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 511988
+  timestamp: 1746228987123
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.24.1-h5ad3122_0.conda
+  sha256: 027499618b9e9c8306490c4af11a329059642ba16086c8a4c3c2596652770a6f
+  md5: 7c2185682ee955c32d65f35822ccc06f
+  depends:
+  - gettext-tools 0.24.1 h5ad3122_0
+  - libasprintf 0.24.1 h5e0f5ae_0
+  - libasprintf-devel 0.24.1 h5e0f5ae_0
+  - libgcc >=13
+  - libgettextpo 0.24.1 h5ad3122_0
+  - libgettextpo-devel 0.24.1 h5ad3122_0
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 509273
+  timestamp: 1746228828727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.24.1-h5888daf_0.conda
+  sha256: 3ba33868630b903e3cda7a9176363cdf02710fb8f961efed5f8200c4d53fb4e3
+  md5: d54305672f0361c2f3886750e7165b5f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3129801
+  timestamp: 1746228937647
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.24.1-h5ad3122_0.conda
+  sha256: 4176d66aa44d070db71f7e80145d2b423faeef702473469bb82cd894dd589c66
+  md5: 66459c6f8b54cea68654198f03d33e7d
+  depends:
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 3530002
+  timestamp: 1746228795208
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-13.3.0-h9576a4e_2.conda
+  sha256: 9425741d57bbcf918fe98cb375508f31de0daa655f3cebe100a43cf7cb46ec39
+  md5: 19e6d3c9cde10a0a9a170a684082588e
+  depends:
+  - gcc 13.3.0.*
+  - gcc_impl_linux-64 13.3.0.*
+  - gfortran_impl_linux-64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54740
+  timestamp: 1740240701423
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-13.3.0-h8a56e6e_2.conda
+  sha256: 49c1616ef109496d63eb131d7f3c891be7f234e8293d8e0f5ceb34e6b7df2ce0
+  md5: 046403ce9f09a7859829b80f18173355
+  depends:
+  - gcc 13.3.0.*
+  - gcc_impl_linux-aarch64 13.3.0.*
+  - gfortran_impl_linux-aarch64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54903
+  timestamp: 1740241371176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-13.3.0-h84c1745_2.conda
+  sha256: 03a45f58b41909d4189fb81ec7f971b60aaccf95a3953049d93ae7d06eb19000
+  md5: 4e21ed177b76537067736f20f54fee0a
+  depends:
+  - gcc_impl_linux-64 >=13.3.0
+  - libgcc >=13.3.0
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 15923784
+  timestamp: 1740240635243
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-13.3.0-h9c0531c_2.conda
+  sha256: 6664b75bbc31cf27a13e2a6664696272022291a13ce192e533c8948e67f7f489
+  md5: 1d3c53798439f97ae32e68fc3ede8a97
+  depends:
+  - gcc_impl_linux-aarch64 >=13.3.0
+  - libgcc >=13.3.0
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13.3.0
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 13179450
+  timestamp: 1740241301137
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-13.3.0-h1917dac_11.conda
+  sha256: e51bcd274ca1ff67b4f32cd772317f43a7f43dad1f8c07d400b4918a9f88b006
+  md5: 85b2fa3c287710011199f5da1bac5b43
+  depends:
+  - binutils_linux-64
+  - gcc_linux-64 13.3.0 h6f18a23_11
+  - gfortran_impl_linux-64 13.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30896
+  timestamp: 1748905884078
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-13.3.0-h2809cf8_11.conda
+  sha256: 4edf049b1b8b55f9aa1c02517249b9399a4f3553dfaccbfc212eed304a980ebb
+  md5: c8da04180dea2ac5341e6e08ee1043ec
+  depends:
+  - binutils_linux-aarch64
+  - gcc_linux-aarch64 13.3.0 h1cd514b_11
+  - gfortran_impl_linux-aarch64 13.3.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30854
+  timestamp: 1748905816932
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gl2ps-1.4.2-hae5d5c5_1.conda
+  sha256: 68f071ea25e79ee427c0d6c35ccc137d66f093a37660a4e41bafe0c49d64f2d6
+  md5: 00e642ec191a19bf806a3915800e9524
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 74102
+  timestamp: 1718542981099
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gl2ps-1.4.2-hedfd65a_1.conda
+  sha256: e6500b15fd2dbd776df204556702bb2c90d037523c18cd0a111c7c0f0d314aa2
+  md5: 6a087dc84254035cbde984f2c010c9ef
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 72023
+  timestamp: 1718542978037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glew-2.1.0-h9c3ff4c_2.tar.bz2
+  sha256: 86f5484e38f4604f7694b14f64238e932e8fd8d7364e86557f4911eded2843ae
+  md5: fb05eb5c47590b247658243d27fc32f1
+  depends:
+  - libgcc-ng >=9.3.0
+  - libglu
+  - libstdcxx-ng >=9.3.0
+  - xorg-libx11
+  - xorg-libxext
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 662569
+  timestamp: 1607113198887
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glew-2.1.0-h01db608_2.tar.bz2
+  sha256: f872cc93507b833ec5f2f08e479cc0074e5d73defe4f91d54f667a324d0b4f61
+  md5: 2a46529de1ff766f31333d3cdff2b734
+  depends:
+  - libgcc-ng >=9.3.0
+  - libglu
+  - libstdcxx-ng >=9.3.0
+  - xorg-libx11
+  - xorg-libxext
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 649830
+  timestamp: 1607113149975
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.84.2-h6287aef_0.conda
+  sha256: 4a9a9d2ce450737dadc1343b27ad123e01758ea70bb2bd087952d2807d768752
+  md5: 704648df3a01d4d24bc2c0466b718d63
+  depends:
+  - glib-tools 2.84.2 h4833e2c_0
+  - libffi >=3.4.6,<3.5.0a0
+  - libglib 2.84.2 h3618099_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 609516
+  timestamp: 1747836756960
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.84.2-h5702d23_0.conda
+  sha256: b9652659fc97c6f6ba65aad416562ff3f423c8f6b9e06e054d266ac42070563d
+  md5: ab19a294f87cf0be9300a7248d481819
+  depends:
+  - glib-tools 2.84.2 h78ca943_0
+  - libffi >=3.4.6,<3.5.0a0
+  - libglib 2.84.2 hc022ef1_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  size: 623239
+  timestamp: 1747836875897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.84.2-h4833e2c_0.conda
+  sha256: eee7655422577df78386513322ea2aa691e7638947584faa715a20488ef6cc4e
+  md5: f2ec1facec64147850b7674633978050
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libglib 2.84.2 h3618099_0
+  license: LGPL-2.1-or-later
+  size: 116819
+  timestamp: 1747836718327
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.84.2-h78ca943_0.conda
+  sha256: ed0eba9ce24c5d6a10a13f6d7645dbf723316eb5fd660f20e786549885c969c6
+  md5: 91c05565359860d763d59a6727c75d63
+  depends:
+  - libgcc >=13
+  - libglib 2.84.2 hc022ef1_0
+  license: LGPL-2.1-or-later
+  size: 127992
+  timestamp: 1747836847302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmock-1.15.2-ha770c72_0.conda
+  sha256: cddaae3c433647872ddb8c93d195ffad927154c82f6abc17013c7764c02e5eb0
+  md5: 28f0e4e7ea2aa02d685b2cf71f1c7164
+  depends:
+  - gtest 1.15.2 h434a139_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6935
+  timestamp: 1722457788931
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmock-1.15.2-h8af1aa0_0.conda
+  sha256: ee2923d9581b88809a7b159f228c43b66c679619dc0510b777b4ad8de335dead
+  md5: c1ba74158521289b04df46f243d461ce
+  depends:
+  - gtest 1.15.2 h70be974_0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6944
+  timestamp: 1722457833604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 460055
+  timestamp: 1718980856608
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
+  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 417323
+  timestamp: 1718980707330
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-h5888daf_0.conda
+  sha256: cac69f3ff7756912bbed4c28363de94f545856b35033c0b86193366b95f5317d
+  md5: 951ff8d9e5536896408e89d63230b8d5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 98419
+  timestamp: 1750079957535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-h5ad3122_0.conda
+  sha256: 957d9bcf7f8b2d8925a9af238189b372ba42c0fdbda4248cd8bd76684781af3d
+  md5: 087ecf989fc23fc50944a06fddf5f3bc
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 101397
+  timestamp: 1750080039341
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-12.2.1-h5ae0cbf_1.conda
+  sha256: e6866409ba03df392ac5ec6f0d6ff9751a685ed917bfbcd8a73f550c5fe83c2b
+  md5: df7835d2c73cd1889d377cfd6694ada4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - adwaita-icon-theme
+  - cairo >=1.18.2,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.82.2,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 2413095
+  timestamp: 1738602910851
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphviz-12.2.1-h044d27a_1.conda
+  sha256: 233f5cda023ac275644e3e3b3663adeca99d7d71cf2379b483d00c3c37163d33
+  md5: c9c0b953e77213e1fd0cdb4a2590ba02
+  depends:
+  - adwaita-icon-theme
+  - cairo >=1.18.2,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.82.2,<3.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 2530145
+  timestamp: 1738603119015
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
+  sha256: a497d2ba34fdfa4bead423cba5261b7e619df3ac491fb0b6231d91da45bd05fc
+  md5: d8d8894f8ced2c9be76dc9ad1ae531ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - gstreamer 1.24.11 hc37bda9_0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2859572
+  timestamp: 1745093626455
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.11-h83ffb7f_0.conda
+  sha256: a13e1059f23497243100b5786e5a7ffac2182885dd56bd7813f518faff959b26
+  md5: 2328f6ad67fc8d33402091e3d770ca73
+  depends:
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - gstreamer 1.24.11 h17c303d_0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxshmfence >=1.3.3,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2806661
+  timestamp: 1745097877029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
+  sha256: 6e93b99d77ac7f7b3eb29c1911a0a463072a40748b96dbe37c18b2c0a90b34de
+  md5: 056d86cacf2b48c79c6a562a2486eb8c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.84.1,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2021832
+  timestamp: 1745093493354
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.11-h17c303d_0.conda
+  sha256: 49a399a7c6e2f3d4ad6338fed8d5f3548baa6edeeaec716cca3505f84f3473fb
+  md5: 8cc29506178d015d91d8b28725f0bd0c
+  depends:
+  - glib >=2.84.1,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 2032739
+  timestamp: 1745095972722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.15.2-h434a139_0.conda
+  sha256: cf2ccc3bbaca3dba1c12087aeaf5cc8f7c665d8678d9a9815d87b360867fc952
+  md5: 0874e26e61c13ae001dc647a650a97ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - gmock 1.15.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 408202
+  timestamp: 1722457782806
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtest-1.15.2-h70be974_0.conda
+  sha256: d53a66dc2642d490ce37d456054a61f11f96485a106e48ee27e1d2ce3fb74cc2
+  md5: 3eb57e558bba17a085b29e24aa747475
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - gmock 1.15.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 396744
+  timestamp: 1722457829031
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+  sha256: d36263cbcbce34ec463ce92bd72efa198b55d987959eab6210cc256a0e79573b
+  md5: 67d00e9cfe751cfe581726c5eff7c184
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - glib-tools
+  - harfbuzz >=11.0.0,<12.0a0
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libxkbcommon >=1.8.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.3,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 5585389
+  timestamp: 1743405684985
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gtk3-3.24.43-hc7d089d_5.conda
+  sha256: e33f6c88c63ea6e53e15fc7b599a18141ef86a211b3770df59024f60e178192b
+  md5: 5c2197efa63776720377d23517a862ce
+  depends:
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - glib-tools
+  - harfbuzz >=11.0.0,<12.0a0
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libxkbcommon >=1.8.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.3,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 5656952
+  timestamp: 1743411517388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+  sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
+  md5: 4d8df0b0db060d33c9a702ada998a8fe
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 318312
+  timestamp: 1686545244763
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
+  sha256: 1e9cc30d1c746d5a3399a279f5f642a953f37d9f9c82fd4d55b301e9c2a23f7c
+  md5: 2aeaeddbd89e84b60165463225814cfc
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 332673
+  timestamp: 1686545222091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.3.0-h9576a4e_2.conda
+  sha256: fa9d0171c17e4c4203a4199fcc35571a25c1f16c0ad992080d4f0ced53bf5aa5
+  md5: 07e8df00b7cd3084ad3ef598ce32a71c
+  depends:
+  - gcc 13.3.0.*
+  - gxx_impl_linux-64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54718
+  timestamp: 1740240712365
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-13.3.0-h8a56e6e_2.conda
+  sha256: de6d25090cfbc836632e55e55a9391ef3b2a6e236dbe0b77465c7d43ec317078
+  md5: dafa9043d805831347c2307d69d8485c
+  depends:
+  - gcc 13.3.0.*
+  - gxx_impl_linux-aarch64 13.3.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 54821
+  timestamp: 1740241381951
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.3.0-hae580e1_2.conda
+  sha256: 7cb36526a5c3e75ae07452aee5c9b6219f62fad9f85cc6d1dab5b21d1c4cc996
+  md5: b55f02540605c322a47719029f8404cc
+  depends:
+  - gcc_impl_linux-64 13.3.0 h1e990d8_2
+  - libstdcxx-devel_linux-64 13.3.0 hc03c837_102
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 13362974
+  timestamp: 1740240672045
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-13.3.0-h7eae8fb_2.conda
+  sha256: 5fa921c34f4eb2fbbb54bbeb1abae1224c6c8d2016856131083f5a53d308741a
+  md5: b747c72c0f42fe1f8ede998c6b386f88
+  depends:
+  - gcc_impl_linux-aarch64 13.3.0 h80a1502_2
+  - libstdcxx-devel_linux-aarch64 13.3.0 h0c07274_102
+  - sysroot_linux-aarch64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 12731271
+  timestamp: 1740241342888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-13.3.0-hb14504d_11.conda
+  sha256: dda6a2765249c40168defea26aa67ff37d4d9fd214fb6e8d4fe0f434033bef87
+  md5: 2ca7575e4f2da39c5ee260e022ab1a6f
+  depends:
+  - binutils_linux-64
+  - gcc_linux-64 13.3.0 h6f18a23_11
+  - gxx_impl_linux-64 13.3.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30844
+  timestamp: 1748905886442
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-13.3.0-h2864abd_11.conda
+  sha256: f4319623bb1d65ee41a47bbdf69a76ce7518de3eb6e8274800d0cf82b959a180
+  md5: 4b43896b3ae5920dc628abeb763f0e12
+  depends:
+  - binutils_linux-aarch64
+  - gcc_linux-aarch64 13.3.0 h1cd514b_11
+  - gxx_impl_linux-aarch64 13.3.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 30796
+  timestamp: 1748905819328
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.2.1-h3beb420_0.conda
+  sha256: 5bd0f3674808862838d6e2efc0b3075e561c34309c5c2f4c976f7f1f57c91112
+  md5: 0e6e192d4b3d95708ad192d957cf3163
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - freetype
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 1730226
+  timestamp: 1747091044218
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-11.2.1-h405b6a2_0.conda
+  sha256: 2f7754c197fc1b7e57cf5b4063298834818889561c0c462b7fe363742defdbd5
+  md5: b55680fc90e9747dc858e7ceb0abc2b2
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - freetype
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libglib >=2.84.1,<3.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 1746366
+  timestamp: 1747094097917
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+  sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
+  md5: bd77f8da987968ec3927990495dc22e4
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 756742
+  timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
+  sha256: 70d1e2d3e0b9ae1b149a31a4270adfbb5a4ceb2f8c36d17feffcd7bcb6208022
+  md5: e1b6676b77b9690d07ea25de48aed97e
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 773862
+  timestamp: 1695661552544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h2d575fe_109.conda
+  sha256: e8669a6d76d415f4fdbe682507ac3a3b39e8f493d2f2bdc520817f80b7cc0753
+  md5: e7a7a6e6f70553a31e6e79c65768d089
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3930078
+  timestamp: 1737516601132
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h6ed7ac7_105.conda
+  sha256: 57db9910da8bcc3b6456ab0e52a8e215b97f30941b416d2b052b3461097a8e09
+  md5: 337b0bbe9c3ee631ec0982c990d21fc2
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4034228
+  timestamp: 1733010297124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+  sha256: 336f29ceea9594f15cc8ec4c45fdc29e10796573c697ee0d57ebb7edd7e92043
+  md5: bbf6f174dcd3254e19a2f5d2295ce808
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 13841
+  timestamp: 1605162808667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_2.tar.bz2
+  sha256: 479a0f95cf3e7d7db795fb7a14337cab73c2c926a5599c8512a3e8f8466f9e54
+  md5: 331add9f855e921695d7b569aa23d5ec
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 13896
+  timestamp: 1605162856037
+- conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+  sha256: fa2071da7fab758c669e78227e6094f6b3608228740808a6de5d6bce83d9e52d
+  md5: 7fe569c10905402ed47024fc481bb371
+  depends:
+  - __unix
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 73563
+  timestamp: 1733928021866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
+  md5: 268203e8b983fddb6412b36f2024e75c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12282786
+  timestamp: 1720853454991
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49765
+  timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+  sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
+  md5: 37f5e1ab0db3691929f37dee78335d1b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 159630
+  timestamp: 1725971591485
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
+  md5: ae8535ff689663fe430bec00be24a854
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 153368
+  timestamp: 1725971683794
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
+  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+  depends:
+  - python >=3.9
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34641
+  timestamp: 1747934053147
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+  sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
+  md5: c85c76dc67d75619a92f51dfbce06992
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.5.2,<6.5.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 33781
+  timestamp: 1736252433366
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+  sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
+  md5: 6837f3eff7dcea42ecd714ce1ac2b108
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11474
+  timestamp: 1733223232820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.5-h1920b20_0.conda
+  sha256: 59a4de9d5daee552b901b0edef28a495016fb4a9d35d3b91d69fc9328a6159ee
+  md5: ec8824a45bd7c50a46788fa16216d6c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc >=13
+  - libglu >=9.0.3,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 688287
+  timestamp: 1743026000524
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.5-h9d5db0e_0.conda
+  sha256: ae2c7a850391b2e35412049e53879d435503c2e5c6806bd71925bb2da3f29c95
+  md5: db269b531654b7491990869c63435252
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc >=13
+  - libglu >=9.0.3,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 711142
+  timestamp: 1743026001983
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jsoncpp-1.9.6-hf42df4d_1.conda
+  sha256: ed4b1878be103deb2e4c6d0eea3c9bdddfd7fc3178383927dce7578fb1063520
+  md5: 7bdc5e2cc11cb0a0f795bdad9732b0f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LicenseRef-Public-Domain OR MIT
+  size: 169093
+  timestamp: 1733780223643
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jsoncpp-1.9.6-h34915d9_1.conda
+  sha256: 12f2d001e4e9ad255f1de139e873876d03d53f16396d73f7849b114eefec5291
+  md5: 2f23d5c1884fac280816ac2e5f858a65
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LicenseRef-Public-Domain OR MIT
+  size: 162312
+  timestamp: 1733779925983
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+  sha256: 2057ca87b313bde5b74b93b0e696f8faab69acd4cb0edebb78469f3f388040c0
+  md5: 5aeabe88534ea4169d4c49998f293d6c
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 239104
+  timestamp: 1703333860145
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
+  sha256: 157e151068d44042c56d6dd6f634d0b2c1fe084114ae56125299f518dd8b1500
+  md5: 720f7b9ccdf426ac73dafcf92f7d7bf4
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 238091
+  timestamp: 1703333994798
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
+  sha256: a922841ad80bd7b222502e65c07ecb67e4176c4fa5b03678a005f39fcc98be4b
+  md5: ad8527bf134a90e1c9ed35fa0b64318c
+  constrains:
+  - sysroot_linux-64 ==2.17
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 943486
+  timestamp: 1729794504440
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
+  sha256: 99731884b26d5801c931f6ed4e1d40f0d1b2efc60ab2d1d49e9b3a6508a390df
+  md5: 40ebaa9844bc99af99fc1beaed90b379
+  constrains:
+  - sysroot_linux-aarch64 ==2.17
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 1113306
+  timestamp: 1729794501866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 117831
+  timestamp: 1646151697040
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+  sha256: 6d4233d97a9b38acbb26e1268bcf8c10a8e79c2aed7e5a385ec3769967e3e65b
+  md5: 1f24853e59c68892452ef94ddd8afd4b
+  depends:
+  - libgcc-ng >=10.3.0
+  license: LGPL-2.1-or-later
+  size: 112327
+  timestamp: 1646166857935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
+  md5: be34c90cce87090d24da64a7c239ca96
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72393
+  timestamp: 1725459421768
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.7-py311h75754e6_0.conda
+  sha256: b1d09c5e2ac26e995af9557c5e09fb241a218a6536ef64f8772bdff025170973
+  md5: c755ebf4d5dbcf4edf2b53775662d864
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 72416
+  timestamp: 1725461219830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
+  md5: 29c10432a2ca1472b53f299ffb2ffa37
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1474620
+  timestamp: 1719463205834
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 508258
+  timestamp: 1664996250081
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+  sha256: 2502904a42df6d94bd743f7b73915415391dd6d31d5f50cb57c0a54a108e7b0a
+  md5: ab05bcf82d8509b4243f07e93bada144
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  size: 604863
+  timestamp: 1664997611416
+- conda: https://conda.anaconda.org/conda-forge/noarch/lark-parser-0.12.0-pyhd8ed1ab_1.conda
+  sha256: 7f1ad9630a87005a90099ad3ff883ac7a3fe5e85b9eb232d1f8ad0a670059cca
+  md5: 222dd97cb2d5da1638de5077da60712f
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 86134
+  timestamp: 1725742423890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
+  sha256: d6a61830a354da022eae93fa896d0991385a875c6bba53c82263a289deda9db8
+  md5: 000e85703f0fd9594c81710dd5066471
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 248046
+  timestamp: 1739160907615
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.17-hc88f144_0.conda
+  sha256: 47cf6a4780dc41caa9bc95f020eed485b07010c9ccc85e9ef44b538fedb5341d
+  md5: b87b1abd2542cf65a00ad2e2461a3083
+  depends:
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 287007
+  timestamp: 1739161069194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_5.conda
+  sha256: de097284f497b391fe9d000c75b684583c30aad172d9508ed05df23ce39d75cb
+  md5: acd9213a63cb62521290e581ef82de80
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 670525
+  timestamp: 1749852860076
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_5.conda
+  sha256: 7ccc28b4395aa12db19c89eba3e949588fa5a4aa315b86bb74cb7097b6703845
+  md5: d3f39175ba27446cab38afd50847cece
+  constrains:
+  - binutils_impl_linux-aarch64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 704456
+  timestamp: 1749852831071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+  sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+  md5: 9344155d33912347b37f0ae6c410a835
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 264243
+  timestamp: 1745264221534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-hfdc4d58_1.conda
+  sha256: f01df5bbf97783fac9b89be602b4d02f94353f5221acfd80c424ec1c9a8d276c
+  md5: 60dceb7e876f4d74a9cbd42bbbc6b9cf
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 227184
+  timestamp: 1745265544057
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_hbbce691_4.conda
+  sha256: 143a586aa67d50622ef703de57b9d43f44945836d6568e0e7aa174bd8c45e0d4
+  md5: 488f260ccda0afaf08acb286db439c2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1311599
+  timestamp: 1736008414161
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h18dbdb1_4.conda
+  sha256: bb6c5fb3b8de5f90735c5252b57efb3c268ee222c755569dac18065f05147670
+  md5: 633b9fe454ffea2aaf29e191d946a83b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - abseil-cpp =20240722.0
+  - libabseil-static =20240722.0=cxx17*
+  license: Apache-2.0
+  license_family: Apache
+  size: 1334844
+  timestamp: 1736008472455
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libacl-2.3.2-h0f662aa_0.conda
+  sha256: 1b704cf161c6f84658a7ac534555ef365ec982f23576b1c4ae4cac4baeb61685
+  md5: ef8039969013acacf5b741092aef2ee7
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 110600
+  timestamp: 1706132570609
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libacl-2.3.2-h883460d_0.conda
+  sha256: 6d24a61f466f50dcab30f16663f5064cb1e0837a64103c21b0e14f265c29e31a
+  md5: b1d08a80bfea3391c32fb429d3dc02f3
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 115093
+  timestamp: 1706132568525
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+  sha256: 410ab78fe89bc869d435de04c9ffa189598ac15bb0fe1ea8ace8fb1b860a2aa3
+  md5: 01ba04e414e47f95c03d6ddd81fd37be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36825
+  timestamp: 1749993532943
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.4-h1e66f74_0.conda
+  sha256: 891844586d02bb528c18fddc6aa14dfd995532fbb8795156d215318e1de242f7
+  md5: 6360d4091c919d6e185f1fc3ac36716e
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 36847
+  timestamp: 1749993545798
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
+  sha256: e30733a729eb6efd9cb316db0202897c882d46f6c20a0e647b4de8ec921b7218
+  md5: 57566a81dd1e5aa3d98ac7582e8bfe03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later
+  size: 53115
+  timestamp: 1746228856865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.24.1-h5e0f5ae_0.conda
+  sha256: 969b002ab70bf2f27fc108c83c07d6e4f4a4fd1a1ad3a8028e625a78a748347b
+  md5: e6dd5b99796423a24ecc42db08ab31da
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later
+  size: 53530
+  timestamp: 1746228742482
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
+  sha256: ccbfc465456133042eea3e8d69bae009893f57a47a786f772c0af382bda7ad99
+  md5: 8f66ed2e34507b7ae44afa31c3e4ec79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libasprintf 0.24.1 h8e693c7_0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 34680
+  timestamp: 1746228884730
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.24.1-h5e0f5ae_0.conda
+  sha256: caec98b6fc50630741e80ed39c06421be84222c6da629e12248fbddccf54dd5e
+  md5: b02fed476ae02f9bbd5ab534dbb57587
+  depends:
+  - libasprintf 0.24.1 h5e0f5ae_0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 34897
+  timestamp: 1746228758454
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h52826cd_2.conda
+  sha256: 8a94e634de73be1e7548deaf6e3b992e0d30c628a24f23333af06ebb3a3e74cb
+  md5: 01de25a48490709850221135890e09eb
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - harfbuzz >=11.0.0,<12.0a0
+  license: ISC
+  size: 152563
+  timestamp: 1743206970222
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-h3c9f632_2.conda
+  sha256: 72551f77103bd9725cc57a1e6dff71059970ccc76c48c45240cdfd1987dfebd8
+  md5: e7714c1e8fdaf41d5125dd73b28667bc
+  depends:
+  - libgcc >=13
+  - freetype >=2.13.3,<3.0a0
+  - harfbuzz >=11.0.0,<12.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  license: ISC
+  size: 173682
+  timestamp: 1743206972213
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-32_h59b9bed_openblas.conda
+  build_number: 32
+  sha256: 1540bf739feb446ff71163923e7f044e867d163c50b605c8b421c55ff39aa338
+  md5: 2af9f3d5c2e39f417ce040f5a35c40c6
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - libcblas   3.9.0   32*_openblas
+  - mkl <2025
+  - liblapacke 3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17330
+  timestamp: 1750388798074
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-32_h1a9f1db_openblas.conda
+  build_number: 32
+  sha256: a257f0c43dd142be7eab85bf78999a869a6938ddb2415202f74724ff51dff316
+  md5: 833718ed1c0b597ce17e5f410bd9b017
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - libcblas   3.9.0   32*_openblas
+  - liblapack  3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapacke 3.9.0   32*_openblas
+  - mkl <2025
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17341
+  timestamp: 1750388911474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-h6c02f8c_3.conda
+  sha256: bad622863b3e4c8f0d107d8efd5b808e52d79cb502a20d700d05357b59a51e8f
+  md5: eead4e74198698d1c74f06572af753bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 2946990
+  timestamp: 1733501899743
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-h4d13611_3.conda
+  sha256: 2793e4d102d5822dfeb71ba1c0844df8357d041810eedf8144a7292921f89498
+  md5: b5042cc0004a036390a6e4b007d77966
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 3049840
+  timestamp: 1733502105682
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-devel-1.86.0-h1a2810e_3.conda
+  sha256: 1bbc13f4bed720af80e67e5df1e609f4efd801ae27d85107c36416de20ebb84c
+  md5: ffe09ce10ce1e03e1e762ab5bc006a35
+  depends:
+  - libboost 1.86.0 h6c02f8c_3
+  - libboost-headers 1.86.0 ha770c72_3
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 37554
+  timestamp: 1733502001252
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-devel-1.86.0-h37bb5a9_3.conda
+  sha256: becf307faa62532c232c8a761469527bdd8f23b1c2243b9b5075f04ce5ac6b34
+  md5: 0cf50fd836e92c72ce0b609339d8325d
+  depends:
+  - libboost 1.86.0 h4d13611_3
+  - libboost-headers 1.86.0 h8af1aa0_3
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 36489
+  timestamp: 1733502210742
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.86.0-ha770c72_3.conda
+  sha256: 322be3cc409ee8b7f46a6e237c91cdcf810bc528af5865f6b7c46cc56ad5f070
+  md5: be60ca34cfa7a867c2911506cad8f7c3
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 13991670
+  timestamp: 1733501914699
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-headers-1.86.0-h8af1aa0_3.conda
+  sha256: 1b0fbba3c07fb7ad91e33795ce7ab6625e1fc89a86759ec357d645f50109831d
+  md5: 3dfbb18ef594487356d106f8ce5d3c2b
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  size: 14031351
+  timestamp: 1733502121821
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py311h5b7b71f_3.conda
+  sha256: 1ae2533b2b3b38fac2e06f742c0cd2dbadcd899c0b21d49fa6ca4f2f1c5d6d92
+  md5: 1f2e5e17b5d0c42dba4c8740b64f5ac3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - boost <0.0a0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  size: 121008
+  timestamp: 1733502281031
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-python-1.86.0-py311hb9acf69_3.conda
+  sha256: 6fc680e0db0d7d557d44862918285e29327f7a5e790fee8add2374f1271401d3
+  md5: 7e015ef14cadca9688a5d1733f8bb927
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - py-boost <0.0a0
+  - boost <0.0a0
+  license: BSL-1.0
+  size: 117377
+  timestamp: 1733502415732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
+  sha256: 462a8ed6a7bb9c5af829ec4b90aab322f8bcd9d8987f793e6986ea873bbd05cf
+  md5: cb98af5db26e3f482bebb80ce9d947d3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 69233
+  timestamp: 1749230099545
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h86ecc28_3.conda
+  sha256: a974f63f71ccb198300c606204846a65a7d62abffcbfbc4f557f71d0243a1fab
+  md5: 76295055ce278970227759bdf3490827
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 69590
+  timestamp: 1749230272157
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
+  sha256: 3eb27c1a589cbfd83731be7c3f19d6d679c7a444c3ba19db6ad8bf49172f3d83
+  md5: 1c6eecffad553bde44c5238770cfb7da
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 33148
+  timestamp: 1749230111397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_3.conda
+  sha256: a9664ec3acc9dbb33425d057154f6802b0c4d723fbb7939ee40eb379dbe5150b
+  md5: 3a4b4fc0864a4dc0f4012ac1abe069a9
+  depends:
+  - libbrotlicommon 1.1.0 h86ecc28_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 32248
+  timestamp: 1749230286642
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
+  sha256: 76e8492b0b0a0d222bfd6081cae30612aa9915e4309396fdca936528ccf314b7
+  md5: 3facafe58f3858eb95527c7d3a3fc578
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.1.0 hb9d3cd8_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 282657
+  timestamp: 1749230124839
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h86ecc28_3.conda
+  sha256: 3a225e42ef7293217177ba9ca8559915f14b74ab238652c7aa32f20a3dbbee2d
+  md5: 2b8199de1016a56c49bfced37c7f0882
+  depends:
+  - libbrotlicommon 1.1.0 h86ecc28_3
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 290695
+  timestamp: 1749230300899
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
+  sha256: 9c84448305e7c9cc44ccec7757cf5afcb5a021f4579aa750a1fa6ea398783950
+  md5: c44c16d6976d2aebbd65894d7741e67e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 120375
+  timestamp: 1741176638215
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.75-h51d75a7_0.conda
+  sha256: d77e8bd8d5714a80c1fa88037e71d5c29f21bae1e9281528006c9c5a6175ac1a
+  md5: c5456e13665779bf7a62dc7724ca2938
+  depends:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 108212
+  timestamp: 1741177682469
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-32_he106b2a_openblas.conda
+  build_number: 32
+  sha256: 92a001fc181e6abe4f4a672b81d9413ca2f22609f8a95327dfcc6eee593ffeb9
+  md5: 3d3f9355e52f269cd8bc2c440d8a5263
+  depends:
+  - libblas 3.9.0 32_h59b9bed_openblas
+  constrains:
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
+  - liblapacke 3.9.0   32*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17308
+  timestamp: 1750388809353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-32_hab92f65_openblas.conda
+  build_number: 32
+  sha256: e902de3cd34d4fc1f7d15b9c9c1d297d90043d5283d28db410d32e45ea4e1a33
+  md5: 2f02a3ea0960118a0a8d45cdd348b039
+  depends:
+  - libblas 3.9.0 32_h1a9f1db_openblas
+  constrains:
+  - liblapack  3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapacke 3.9.0   32*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17335
+  timestamp: 1750388919351
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.7-default_h1df26ce_0.conda
+  sha256: 4194c75a91a9c790cbe96c3c33fc2f388274d1be85ec884ce7c88d7e8f9d96f2
+  md5: f9ef7bce54a7673cdbc2fadd8bca1956
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20925717
+  timestamp: 1749876303353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp20.1-20.1.7-default_h7d4303a_0.conda
+  sha256: f8c8e4a4fc13ec9ea1cf770192bafbf87f34c1bcc5d049e605b154dd02c2e6f8
+  md5: b698f9517041dcf9b54cdb95f08860e3
+  depends:
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 20483759
+  timestamp: 1749877025982
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.7-default_he06ed0a_0.conda
+  sha256: 6541d19a1659062dbf8823d6a1206e28f788369bcf7af9171d7c9069c1d35932
+  md5: 846875a174de6b6ff19e205a7d90eb74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 12116245
+  timestamp: 1749876520951
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-20.1.7-default_h9e36cb9_0.conda
+  sha256: 8cc6a60400635627c482a0edb9a34b4693643702f966900757b8b5917a7fdc83
+  md5: bd57f9ace2cde6f3ecbacc3e2d70bcdc
+  depends:
+  - libgcc >=13
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 11880522
+  timestamp: 1749877272069
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+  sha256: cb83980c57e311783ee831832eb2c20ecb41e7dee6e86e8b70b8cef0e43eab55
+  md5: d4a250da4737ee127fb1fa6452a9002e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4523621
+  timestamp: 1749905341688
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h5cdc715_5.conda
+  sha256: f3282d27be35e5d29b5b798e5136427ec798916ee6374499be7b7682c8582b72
+  md5: ac0333d338076ef19170938bbaf97582
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4550533
+  timestamp: 1749906839681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
+  sha256: b6c5cf340a4f80d70d64b3a29a7d9885a5918d16a5cb952022820e6d3e79dc8b
+  md5: 45f6713cb00f124af300342512219182
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 449910
+  timestamp: 1749033146806
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.14.1-h6702fde_0.conda
+  sha256: 13f7cc9f6b4bdc9a3544339abf2662bc61018c415fe7a1518137db782eb85343
+  md5: 1d92dbf43358f0774dc91764fa77a9f5
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.64.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 469143
+  timestamp: 1749033114882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+  sha256: 8420748ea1cc5f18ecc5068b4f24c7a023cc9b20971c99c824ba10641fb95ddf
+  md5: 64f0c503da58ec25ebd359e4d990afa8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 72573
+  timestamp: 1747040452262
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.24-he377734_0.conda
+  sha256: dd0e4baa983803227ec50457731d6f41258b90b3530f579b5d3151d5a98af191
+  md5: f0b3d6494663b3385bf87fc206d7451a
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 70417
+  timestamp: 1747040440762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
+  sha256: f53458db897b93b4a81a6dbfd7915ed8fa4a54951f97c698dde6faa028aadfd2
+  md5: 4c0ab57463117fbb8df85268415082f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  size: 246161
+  timestamp: 1749904704373
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.125-h86ecc28_0.conda
+  sha256: 4413fda35527cf7a746c5e386fa5406349c0948d51fc20f7896732795a369e5d
+  md5: c5e4a8dad08e393b3616651e963304e5
+  depends:
+  - libgcc >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  size: 252778
+  timestamp: 1749904786465
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+  sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+  md5: fb640d776fc92b682a14e001980825b1
+  depends:
+  - ncurses
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 148125
+  timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
+  md5: c151d5eb730e9b7480e6d48c0fc44048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 44840
+  timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_2.conda
+  sha256: 8962abf38a58c235611ce356b9899f6caeb0352a8bce631b0bcc59352fda455e
+  md5: cf105bce884e4ef8c8ccdca9fe6695e7
+  depends:
+  - libglvnd 1.7.0 hd24410f_2
+  license: LicenseRef-libglvnd
+  size: 53551
+  timestamp: 1731330990477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 115123
+  timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
+  md5: 96ae6083cd1ac9f6bc81631ac835b317
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 438992
+  timestamp: 1685726046519
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
+  sha256: 33ab03438aee65d6aa667cf7d90c91e5e7d734c19a67aa4c7040742c0a13d505
+  md5: db0bfbe7dd197b68ad5f30333bae6ce0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.7.0.*
+  license: MIT
+  license_family: MIT
+  size: 74427
+  timestamp: 1743431794976
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.7.0-h5ad3122_0.conda
+  sha256: e3a0d95fe787cccf286f5dced9fa9586465d3cd5ec8e04f7ad7f0e72c4afd089
+  md5: d41a057e7968705dae8dcb7c8ba2c8dd
+  depends:
+  - libgcc >=13
+  constrains:
+  - expat 2.7.0.*
+  license: MIT
+  license_family: MIT
+  size: 73155
+  timestamp: 1743432002397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
+  md5: ede4673863426c0883c0063d853bbd85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 57433
+  timestamp: 1743434498161
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.6-he21f813_1.conda
+  sha256: 608b8c8b0315423e524b48733d91edd43f95cb3354a765322ac306a858c2cd2e
+  md5: 15a131f30cae36e9a655ca81fee9a285
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 55847
+  timestamp: 1743434586764
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+  sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
+  md5: ee48bf17cc83a00f59ca1494d5646869
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 394383
+  timestamp: 1687765514062
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
+  md5: 520b12eab32a92e19b1f239ac545ec03
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 371550
+  timestamp: 1687765491794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.13.3-ha770c72_1.conda
+  sha256: 7be9b3dac469fe3c6146ff24398b685804dfc7a1de37607b84abd076f57cc115
+  md5: 51f5be229d83ecd401fb369ab96ae669
+  depends:
+  - libfreetype6 >=2.13.3
+  license: GPL-2.0-only OR FTL
+  size: 7693
+  timestamp: 1745369988361
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.13.3-h8af1aa0_1.conda
+  sha256: c1bb6726b054b00ad509b9ace5e04f4bfe97e6fdaf5c4473c537e6c03d1f660b
+  md5: 2d4a1c3dcabb80b4a56d5c34bdacea08
+  depends:
+  - libfreetype6 >=2.13.3
+  license: GPL-2.0-only OR FTL
+  size: 7774
+  timestamp: 1745370050680
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.13.3-h48d6fc4_1.conda
+  sha256: 7759bd5c31efe5fbc36a7a1f8ca5244c2eabdbeb8fc1bee4b99cf989f35c7d81
+  md5: 3c255be50a506c50765a93a6644f32fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libpng >=1.6.47,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.13.3
+  license: GPL-2.0-only OR FTL
+  size: 380134
+  timestamp: 1745369987697
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.13.3-he93130f_1.conda
+  sha256: 9f189f75bb79f6b97c48804e89b4f1db5dc3fba5729551e4cbd2deca98580635
+  md5: 51eae9012d75b8f7e4b0adfe61a83330
+  depends:
+  - libgcc >=13
+  - libpng >=1.6.47,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.13.3
+  license: GPL-2.0-only OR FTL
+  size: 408198
+  timestamp: 1745370049871
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+  sha256: 59a87161212abe8acc57d318b0cc8636eb834cdfdfddcf1f588b5493644b39a3
+  md5: 9e60c55e725c20d23125a5f0dd69af5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.1.0=*_3
+  - libgomp 15.1.0 h767d61c_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 824921
+  timestamp: 1750808216066
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_3.conda
+  sha256: a08e3f89d4cd7c5e18a7098419e378a8506ebfaf4dc1eaac59bf7b962ca66cdb
+  md5: 409b902521be20c2efb69d2e0c5e3bc8
+  depends:
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 15.1.0 he277a41_3
+  - libgcc-ng ==15.1.0=*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 510464
+  timestamp: 1750808926824
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-13.3.0-hc03c837_102.conda
+  sha256: 538544a2e0651bfeb0348ca6469b6b608606f6080a0b5a531af3a3852fec0215
+  md5: 4c1d6961a6a54f602ae510d9bf31fa60
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2597400
+  timestamp: 1740240211859
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-13.3.0-h0c07274_102.conda
+  sha256: ad24ec07c1931a743a9deb15da171a7c8f2dbabe5efb0754e890d3921c293737
+  md5: c4d285f4f8b3fc524e8f42e8fad6cb25
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2063715
+  timestamp: 1740240850418
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_3.conda
+  sha256: b0b0a5ee6ce645a09578fc1cb70c180723346f8a45fdb6d23b3520591c6d6996
+  md5: e66f2b8ad787e7beb0f846e4bd7e8493
+  depends:
+  - libgcc 15.1.0 h767d61c_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29033
+  timestamp: 1750808224854
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.1.0-he9431aa_3.conda
+  sha256: 222eedd38467f7af8fb703c16cc1abf83038e7b6a09f707bbb4340e8ed589e14
+  md5: 831062d3b6a4cdfdde1015be90016102
+  depends:
+  - libgcc 15.1.0 he277a41_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29009
+  timestamp: 1750808930406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
+  sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
+  md5: 8504a291085c9fb809b66cabd5834307
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgpg-error >=1.55,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 590353
+  timestamp: 1747060639058
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-lib-1.11.1-h86ecc28_0.conda
+  sha256: 5c572886ae3bf8f55fbc8f18275317679b559a9dd00cf1f128d24057dc6de70e
+  md5: 50df370cbbbcfb4aa67556879e6643a1
+  depends:
+  - libgcc >=13
+  - libgpg-error >=1.55,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 652592
+  timestamp: 1747060671875
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+  sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
+  md5: 68fc66282364981589ef36868b1a7c78
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.45,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 177082
+  timestamp: 1737548051015
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgd-2.3.3-hc8d7b1d_11.conda
+  sha256: 7e199bb390f985b34aee38cdb1f0d166abc09ed44bd703a1b91a3c6cd9912d45
+  md5: d256b0311b7a207a2c6b68d2b399f707
+  depends:
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.45,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 191033
+  timestamp: 1737548098172
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
+  sha256: 104f2341546e295d1136ab3010e81391bd3fd5be0f095db59266e8eba2082d37
+  md5: 2ee6d71b72f75d50581f2f68e965efdb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 171165
+  timestamp: 1746228870846
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.24.1-h5ad3122_0.conda
+  sha256: 3dc0c79b5780d1155ed38a9b4e484d5bd3ea8d5f7e825cff69741cf8dc53313f
+  md5: 54bb1208da39417046f68daa603a37eb
+  depends:
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 217039
+  timestamp: 1746228750642
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
+  sha256: a9a0cba030778eb2944a1f235dba51e503b66f8be0ce6f55f745173a515c3644
+  md5: 8f04c7aae6a46503bc36d1ed5abc8c7c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgettextpo 0.24.1 h5888daf_0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 37234
+  timestamp: 1746228897993
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.24.1-h5ad3122_0.conda
+  sha256: 5fbd5afb2a48282c9b147c068c513bfdfaab22ffdb5eae6c6bc573d44f08d791
+  md5: 376a04253d0a8345e67fc01ceae504c5
+  depends:
+  - libgcc >=13
+  - libgettextpo 0.24.1 h5ad3122_0
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 37390
+  timestamp: 1746228765836
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_3.conda
+  sha256: 77dd1f1efd327e6991e87f09c7c97c4ae1cfbe59d9485c41d339d6391ac9c183
+  md5: bfbca721fd33188ef923dfe9ba172f29
+  depends:
+  - libgfortran5 15.1.0 hcea5267_3
+  constrains:
+  - libgfortran-ng ==15.1.0=*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29057
+  timestamp: 1750808257258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.1.0-he9431aa_3.conda
+  sha256: 9459e5e273397ee6680ea2f1f4bd64161f58a198e36a9983737f494642e08535
+  md5: 2987b138ed84460e6898daab172e9798
+  depends:
+  - libgfortran5 15.1.0 hbc25352_3
+  constrains:
+  - libgfortran-ng ==15.1.0=*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29043
+  timestamp: 1750808952391
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_3.conda
+  sha256: eea6c3cf22ad739c279b4d665e6cf20f8081f483b26a96ddd67d4df3c88dfa0a
+  md5: 530566b68c3b8ce7eec4cd047eae19fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 1565627
+  timestamp: 1750808236464
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.1.0-hbc25352_3.conda
+  sha256: c835503233b6114387e552fc549437657f893e06b684e42aff3739fef2bae235
+  md5: eb1421397fe5db5ad4c3f8d611dd5117
+  depends:
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 1140270
+  timestamp: 1750808938364
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
+  md5: 928b8be80851f5d8ffb016f9c81dae7a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - libglx 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 134712
+  timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_2.conda
+  sha256: 3e954380f16255d1c8ae5da3bd3044d3576a0e1ac2e3c3ff2fe8f2f1ad2e467a
+  md5: 0d00176464ebb25af83d40736a2cd3bb
+  depends:
+  - libglvnd 1.7.0 hd24410f_2
+  - libglx 1.7.0 hd24410f_2
+  license: LicenseRef-libglvnd
+  size: 145442
+  timestamp: 1731331005019
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.2-h3618099_0.conda
+  sha256: a6b5cf4d443044bc9a0293dd12ca2015f0ebe5edfdc9c4abdde0b9947f9eb7bd
+  md5: 072ab14a02164b7c0c089055368ff776
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  constrains:
+  - glib 2.84.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3955066
+  timestamp: 1747836671118
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.84.2-hc022ef1_0.conda
+  sha256: a74d52adc3b913e75185c0afaf9403c85f47c2c6ad585fdbd16f29b6c364a848
+  md5: 51323eab8e9f049d001424828c4c25a4
+  depends:
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  constrains:
+  - glib 2.84.2 *_0
+  license: LGPL-2.1-or-later
+  size: 4016850
+  timestamp: 1747836804570
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
+  sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
+  md5: 8422fcc9e5e172c91e99aef703b3ce65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  license: SGI-B-2.0
+  size: 325262
+  timestamp: 1748692137626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.3-h5ad3122_1.conda
+  sha256: ddb72f17f6ec029069cddd2e489e63e371e75661cd2408509370508490bb23ad
+  md5: 4d836b60421894bf9a6c77c8ca36782c
+  depends:
+  - libgcc >=13
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  license: SGI-B-2.0
+  size: 310655
+  timestamp: 1748692200349
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  md5: 434ca7e50e40f4918ab701e3facd59a0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  size: 132463
+  timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_2.conda
+  sha256: 57ec3898a923d4bcc064669e90e8abfc4d1d945a13639470ba5f3748bd3090da
+  md5: 9e115653741810778c9a915a2f8439e7
+  license: LicenseRef-libglvnd
+  size: 152135
+  timestamp: 1731330986070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
+  md5: c8013e438185f33b13814c5c488acd5c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 75504
+  timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_2.conda
+  sha256: 6591af640cb05a399fab47646025f8b1e1a06a0d4bbb4d2e320d6629b47a1c61
+  md5: 1d4269e233636148696a67e2d30dad2a
+  depends:
+  - libglvnd 1.7.0 hd24410f_2
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 77736
+  timestamp: 1731330998960
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
+  sha256: 43710ab4de0cd7ff8467abff8d11e7bb0e36569df04ce1c099d48601818f11d1
+  md5: 3cd1a7238a0dd3d0860fdefc496cc854
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 447068
+  timestamp: 1750808138400
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_3.conda
+  sha256: a6654342666271da9c396a41ea745dc6e56574806b42abb2be61511314f5cc40
+  md5: b79b8a69669f9ac6311f9ff2e6bffdf2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 449966
+  timestamp: 1750808867863
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
+  sha256: 697334de4786a1067ea86853e520c64dd72b11a05137f5b318d8a444007b5e60
+  md5: 2bd47db5807daade8500ed7ca4c512a4
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  size: 312184
+  timestamp: 1745575272035
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.55-h5ad3122_0.conda
+  sha256: a744c0a137a084af7cee4a33de9bffb988182b5be4edb8a45d51d2a1efd3724c
+  md5: 39f742598d0f18c8e1cb01712bc03ee8
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  license: LGPL-2.1-only
+  size: 327973
+  timestamp: 1745575312848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+  sha256: d14c016482e1409ae1c50109a9ff933460a50940d2682e745ab1c172b5282a69
+  md5: 804ca9e91bcaea0824a341d55b1684f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.4,<2.14.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2423200
+  timestamp: 1731374922090
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.2-default_h2c612a5_1001.conda
+  sha256: 8c7bf410afb4f068063c718a8691de611eeb75f3d0c6122698c7961e90820445
+  md5: 8f42119cdfd1ac905e19f0eeebe9ccfa
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.4,<2.14.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2436762
+  timestamp: 1731374851939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
+  sha256: 18a4afe14f731bfb9cf388659994263904d20111e42f841e9eea1bb6f91f4ab4
+  md5: e796ff8ddc598affdf7c173d6145f087
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  size: 713084
+  timestamp: 1740128065462
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-hc99b53d_1.conda
+  sha256: 3db14977036fe1f511a6dbecacbeff3fdb58482c5c0cf87a2ea3232f5a540836
+  md5: 81541d85a45fbf4d0a29346176f1f21c
+  depends:
+  - libgcc >=13
+  license: LGPL-2.1-only
+  size: 718600
+  timestamp: 1740130562607
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-cmake2-2.17.2-hac33072_0.conda
+  sha256: 4bace3310a094d54dbccd211c0c6b28152d4f8fe9d70c7eae33279eb1584242d
+  md5: ca93261530c18fcd1dc8ce9eb202f7e8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 266880
+  timestamp: 1715202041745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-cmake2-2.17.2-h0a1ffab_0.conda
+  sha256: cd8714d9bd2bcce9846653369261ef260535df2b501c46a0b3c8fc6abd8c5b01
+  md5: 85e2f1a8cfb7f9aa1973a9a45b5add63
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  size: 268913
+  timestamp: 1715202151197
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libignition-math6-6.15.1-py311he92c4ec_2.conda
+  sha256: 42a3d7a8e78c0acc2a7e4296809a9fd2172f9e1e0d3224416a37eb462543dbbb
+  md5: 45cf88b8d51bc7f312f0d89a1f3f3832
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=13
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - libstdcxx >=13
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 1162236
+  timestamp: 1725376325337
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libignition-math6-6.15.1-py311hafc0cf7_2.conda
+  sha256: 5ee4c1888edd963ae8d4b10c6dc7b9307db5dec6b891511306076e367e57a800
+  md5: 65ccd28006d173efc27dff99f0c8e6fe
+  depends:
+  - eigen
+  - libgcc >=13
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - libstdcxx >=13
+  - pybind11-abi 4
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 982295
+  timestamp: 1725385138624
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+  sha256: 98b399287e27768bf79d48faba8a99a2289748c65cd342ca21033fab1860d4a4
+  md5: 9fa334557db9f63da6c9285fd2a48638
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 628947
+  timestamp: 1745268527144
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.1.0-h86ecc28_0.conda
+  sha256: c7e4f017eeadcabb30e2a95dae95aad27271d633835e55e5dae23c932ae7efab
+  md5: a689388210d502364b79e8b19e7fa2cb
+  depends:
+  - libgcc >=13
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 653054
+  timestamp: 1745268199701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-32_h7ac8fdf_openblas.conda
+  build_number: 32
+  sha256: 5b55a30ed1b3f8195dad9020fe1c6d0f514829bfaaf0cf5e393e93682af009f2
+  md5: 6c3f04ccb6c578138e9f9899da0bd714
+  depends:
+  - libblas 3.9.0 32_h59b9bed_openblas
+  constrains:
+  - libcblas   3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapacke 3.9.0   32*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17316
+  timestamp: 1750388820745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-32_h411afd4_openblas.conda
+  build_number: 32
+  sha256: 9d88f242d138e23bcaf3c1f2d41b53cef5594b1fd9da84dd35ec7e944a946de3
+  md5: 8d143759d5a22e9975a996bd13eeb8f0
+  depends:
+  - libblas 3.9.0 32_h1a9f1db_openblas
+  constrains:
+  - libcblas   3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapacke 3.9.0   32*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17308
+  timestamp: 1750388926844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-32_he2f377e_openblas.conda
+  build_number: 32
+  sha256: 48e1da503af1b8cfc48c1403c1ea09a5570ce194077adad3d46f15ea95ef4253
+  md5: 54e7f7896d0dbf56665bcb0078bfa9d2
+  depends:
+  - libblas 3.9.0 32_h59b9bed_openblas
+  - libcblas 3.9.0 32_he106b2a_openblas
+  - liblapack 3.9.0 32_h7ac8fdf_openblas
+  constrains:
+  - blas 2.132   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17316
+  timestamp: 1750388832284
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-32_hc659ca5_openblas.conda
+  build_number: 32
+  sha256: 89f156c2d0290819e2ec3e27b06a46fd2981f45f5e30522195601a9b69ca17ee
+  md5: 1cd2cbdb80386aae8c584ab9f1175ca6
+  depends:
+  - libblas 3.9.0 32_h1a9f1db_openblas
+  - libcblas 3.9.0 32_hab92f65_openblas
+  - liblapack 3.9.0 32_h411afd4_openblas
+  constrains:
+  - blas 2.132   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17344
+  timestamp: 1750388934792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.7-he9d0ab4_0.conda
+  sha256: 5c51416c10e84ac6a73560c82e20f99788b1395ce431c450391966d07a444fa6
+  md5: 63f1accca4913e6b66a2d546c30ff4db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 43026762
+  timestamp: 1749836200754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.7-h07bd352_0.conda
+  sha256: b97cf8cdb709099a0a4daa6cf16ca4104ff0ea2c1b37d4b648d5849eaf70ed59
+  md5: 391cbb3bd5206abf6601efc793ee429e
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 42121254
+  timestamp: 1749831904453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
+  md5: 1a580f7796c7bf6393fddb8bbbde58dc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 112894
+  timestamp: 1749230047870
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.1-h86ecc28_2.conda
+  sha256: 498ea4b29155df69d7f20990a7028d75d91dbea24d04b2eb8a3d6ef328806849
+  md5: 7d362346a479256857ab338588190da0
+  depends:
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 125103
+  timestamp: 1749232230009
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
+  sha256: 329e66330a8f9cbb6a8d5995005478188eb4ba8a6b6391affa849744f4968492
+  md5: f61edadbb301530bd65a32646bd81552
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  license: 0BSD
+  size: 439868
+  timestamp: 1749230061968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.1-h86ecc28_2.conda
+  sha256: 3bd4de89c0cf559a944408525460b3de5495b4c21fb92c831ff0cc96398a7272
+  md5: 236d1ebc954a963b3430ce403fbb0896
+  depends:
+  - libgcc >=13
+  - liblzma 5.8.1 h86ecc28_2
+  license: 0BSD
+  size: 440873
+  timestamp: 1749232400775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h00e09a9_116.conda
+  sha256: 8c389b867452b13e7a2e0cf9c8120e0124a4ac1ab419fab23a565e2659084840
+  md5: 417864857bdb6c2be2e923e89bffd2e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzip >=1.11.2,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 834890
+  timestamp: 1733232226707
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnetcdf-4.9.2-nompi_h46655bb_116.conda
+  sha256: 3cef53598ba8cad6b5dd3ddedafe681f439df84599c91cd446f026532851b4d8
+  md5: 94e5e219d5a306226c30472cfa429285
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzip >=1.11.2,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.4.0,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  size: 852231
+  timestamp: 1733232606148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+  sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+  md5: 19e57602824042dfd0446292ef90488b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 647599
+  timestamp: 1729571887612
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+  sha256: c093c6d370aadbf0409c20b6c54c488ee2f6fea976181919fcc63e87ee232673
+  md5: f52c614fa214a8bedece9421c771670d
+  depends:
+  - c-ares >=1.32.3,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 714610
+  timestamp: 1729571912479
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33731
+  timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h86ecc28_1.conda
+  sha256: c0dc4d84198e3eef1f37321299e48e2754ca83fd12e6284754e3cb231357c3a5
+  md5: d5d58b2dc3e57073fe22303f5fed4db7
+  depends:
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 34831
+  timestamp: 1750274211
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+  sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+  md5: 7c7927b404672409d9917d49bff5f2d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 33418
+  timestamp: 1734670021371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libntlm-1.4-hf897c2e_1002.tar.bz2
+  sha256: 0e303d7a8845391bd1634efb65dc9d9b82b5608ebeb32fb77a56d1ed696d2eee
+  md5: 835c7c4137821de5c309f4266a51ba89
+  depends:
+  - libgcc-ng >=9.3.0
+  license: LGPL-2.1-or-later
+  size: 39449
+  timestamp: 1609781865660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+  sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
+  md5: 68e52064ed3897463c0e958ab5c8f91b
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 218500
+  timestamp: 1745825989535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
+  sha256: 2c1b7c59badc2fd6c19b6926eabfce906c996068d38c2972bd1cfbe943c07420
+  md5: 319df383ae401c40970ee4e9bc836c7a
+  depends:
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 220653
+  timestamp: 1745826021156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_0.conda
+  sha256: 225f4cfdb06b3b73f870ad86f00f49a9ca0a8a2d2afe59440521fafe2b6c23d9
+  md5: 323dc8f259224d13078aaf7ce96c3efe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5916819
+  timestamp: 1750379877844
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.30-pthreads_h9d3fd7e_0.conda
+  sha256: be2e84de39422a8a4241ceff5145913a475571a9ed5729f435c715ad8d9db266
+  md5: 7c3670fbc19809070c27948efda30c4b
+  depends:
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4960761
+  timestamp: 1750379264152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py311h8702e32_613.conda
+  sha256: 899cf9e98eaae73e27b6a3c5f20f4252b21da5f13c31b52d677b75262a69894e
+  md5: 88d06d0ca51cf8fae58c1b56ef7839c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=7.1.0,<8.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-hetero-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-intel-npu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-ir-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-onnx-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-paddle-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-pytorch-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.5.0,<2024.5.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.2,<3.4.0a0
+  - qt6-main >=6.7.3,<6.9.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 30959063
+  timestamp: 1734358941109
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py311h285173e_13.conda
+  sha256: 46a6d33858879303871a237e56ae5dc8ef62606760a651ca5fb40e3ddb5ba65b
+  md5: 2931d212d28c40510485872c98c785af
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=7.1.0,<8.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-auto-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-hetero-plugin >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-ir-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-onnx-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-paddle-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-pytorch-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.5.0,<2024.5.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.5.0,<2024.5.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.2,<3.4.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  size: 20070600
+  timestamp: 1734362474777
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+  sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
+  md5: 7df50d44d4a14d6c31a2c54f2cd92157
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  size: 50757
+  timestamp: 1731330993524
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
+  sha256: e359df399fb2f308774237384414e318fac8870c1bf6481bdc67ae16e0bd2a02
+  md5: cf9d12bfab305e48d095a4c79002c922
+  depends:
+  - libglvnd 1.7.0 hd24410f_2
+  license: LicenseRef-libglvnd
+  size: 56355
+  timestamp: 1731331001820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.5.0-hac27bb2_0.conda
+  sha256: 1f71a7a52cca4ffbd205f93a900ec7ac32bf41c09c89c256ca66c547287bb263
+  md5: 9b7a4ae9edab6f9604f56b790c3e1d02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 5514235
+  timestamp: 1732895282760
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.5.0-hd7d4d4f_0.conda
+  sha256: 4233ba280bc621f6bf2dd63c2d9267e77efea79383b1e3b6c7a4fb98802c8b9f
+  md5: 7917593cbbb44fc42fd82c80c3ade623
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 5004136
+  timestamp: 1732888525696
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.5.0-hd7d4d4f_0.conda
+  sha256: a505b95f5e2b0d2e2f034d844514fc19c785f980c98e76f2f5e665d785cf1f06
+  md5: 2882dac1b23547ba9669a17ac52748bd
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 8542314
+  timestamp: 1732888546260
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.5.0-h4d9b6c2_0.conda
+  sha256: 0c7f3410689a73abce1219aae4eb1c680ef9b49f78ef10e44ce5d8248c4a8a25
+  md5: c787d5a3d5b0776f0336004583297536
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 110859
+  timestamp: 1732895305563
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.5.0-hf15766e_0.conda
+  sha256: b23d4b4da985d54c07b1c696d3a21f8e5a2b77138e2f7ebb9e4a2125d1ec1b90
+  md5: 87139e43604eeb9c22275d0be79a036e
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 107502
+  timestamp: 1732888576535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.5.0-h4d9b6c2_0.conda
+  sha256: ac4fd5ac79f7a36231556cf4ee623ac3e8735e43da1e4bc5c46bf9c469cd1074
+  md5: ad1ed56f60ec9a8e710703f38b860315
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 237878
+  timestamp: 1732895319611
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.5.0-hf15766e_0.conda
+  sha256: 0efa6e975c95af02f5b86d4f3d5f5e901fe667a5b0b0ede4eeb99e4eb081bebe
+  md5: 968c9121574914ae6101a3efe327ffab
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  - tbb >=2021.13.0
+  size: 223148
+  timestamp: 1732888587549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.5.0-h3f63f65_0.conda
+  sha256: 62df96bd821eb8734965d7d7dd22703cd1e13d4b635cc08cc4c87028d427b55d
+  md5: 5bcc0022e2565606e3af7395ec3e156d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  size: 196712
+  timestamp: 1732895334039
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.5.0-h6ef32b0_0.conda
+  sha256: 58e0332a109537457d1bbd696ef26b7026dc67570cf037628756927525746764
+  md5: fdf03aea2cd2e0e0dc847d4ff3d2904e
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  size: 184194
+  timestamp: 1732888598871
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.5.0-hac27bb2_0.conda
+  sha256: 44661d1ee58481a77af7bac269968dae430c2f54003613af3b76595555c112b6
+  md5: 594ab1b892569c9cd15bcae9781a42b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 12307696
+  timestamp: 1732895348960
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.5.0-hac27bb2_0.conda
+  sha256: e410af906d75a880d93fcaf56b30efd28262751b50cae7db88b076602498350a
+  md5: 485e057ea6a17096b0539ca7473e4829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - ocl-icd >=2.3.2,<3.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 9492513
+  timestamp: 1732895398556
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.5.0-hac27bb2_0.conda
+  sha256: 841d84663bbc1562cdd445fa199fdd835121936a1f6abc161e6f055a819db9cd
+  md5: f0a9e23aa51b84be0a74a4518d4020ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  size: 968361
+  timestamp: 1732895433119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.5.0-h3f63f65_0.conda
+  sha256: 1e708b6ae887aea1af2f13a17e005059a9b2b5b6fdacf8563b350963ac23f5d0
+  md5: ae37e91183788f64935657b255cbff21
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  size: 207421
+  timestamp: 1732895446002
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.5.0-h6ef32b0_0.conda
+  sha256: a6d4427ab09a9a368bee3ff6d6d7865bef4c612572c1e43feef701510d3ced9b
+  md5: 303abca080fbcae1a4ab25fd6d3ef20b
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  - pugixml >=1.14,<1.15.0a0
+  size: 194989
+  timestamp: 1732888611832
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.5.0-h5c8f2c3_0.conda
+  sha256: a121addb8a11de7e8ce9dd9e066beed3331a0d495e20c3648678e6c62a8d40ab
+  md5: 23e82dd5b616fa8879620609428791c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 1621729
+  timestamp: 1732895458321
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.5.0-haa99d6a_0.conda
+  sha256: dea592b50ab0796eaf3da31b2fc367d5d5dce9da1f475b73d1bef3f41d04884d
+  md5: bbe328828404e8f1d9fc3128cc8b0b53
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 1458225
+  timestamp: 1732888623490
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.5.0-h5c8f2c3_0.conda
+  sha256: e6ee95c7d28261ec8e90076bcaf2dc521ff4d4322f662cbd3e91ada9a1f07880
+  md5: ecf440381b082f7d2b9cb66d62d76efb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 658113
+  timestamp: 1732895472761
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.5.0-haa99d6a_0.conda
+  sha256: 6b95d4309ccc5b4b98c2bb263eaa66e80c69f2661e3afeeaee183c140c84cc28
+  md5: c306e99e1b99294478912f2b766eb4d3
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  size: 609117
+  timestamp: 1732888636823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.5.0-h5888daf_0.conda
+  sha256: f7e04c73d88a3c7cc6e58f34e878b7f8fa5dbd5ed198ed6c69d6901bac35b739
+  md5: a5baecc3ef0d0cca99d08cf335c06c03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  size: 1102383
+  timestamp: 1732895486898
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.5.0-h5ad3122_0.conda
+  sha256: 570ad01cb055f52ddc69e4243f65e4f048130fa9cdae69c1b1cfaef98f799b59
+  md5: c9014176771facb2565f42eede0e94c1
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  size: 1021520
+  timestamp: 1732888648727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.5.0-h6481b9d_0.conda
+  sha256: 86fc768f2b6f6ac659531f1a1a111eaf16798ec4d9d1e2e16366fe38635d146f
+  md5: 698ad10adfc7aa6553392677fffe054f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - snappy >=1.2.1,<1.3.0a0
+  size: 1311249
+  timestamp: 1732895503314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.5.0-he24a241_0.conda
+  sha256: 651bd6452bc37cbadeefd4942e07b80bdd893574d51962fbfcc0aece56f0583e
+  md5: 1dded3e7fbb49dde6a35e4e1cca4793f
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - snappy >=1.2.1,<1.3.0a0
+  size: 1218204
+  timestamp: 1732888661860
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.5.0-h5888daf_0.conda
+  sha256: 7842fedd0ca9f319b3727da4ff0f911742a9398babf852fefffd407bd73f3d20
+  md5: 1c25d4e1965049a85c83762eaecb4436
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libopenvino 2024.5.0 hac27bb2_0
+  - libstdcxx >=13
+  size: 485880
+  timestamp: 1732895516864
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.5.0-h5ad3122_0.conda
+  sha256: 78db09a57d5cb1f4fc7ea6aac46c23588869a9b57cd1c863a3f6460dfc779ab9
+  md5: 05d085ba8ccf33d75c0f57565c194382
+  depends:
+  - libgcc >=13
+  - libopenvino 2024.5.0 hd7d4d4f_0
+  - libstdcxx >=13
+  size: 448771
+  timestamp: 1732888676221
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
+  sha256: 786d43678d6d1dc5f88a6bad2d02830cfd5a0184e84a8caa45694049f0e3ea5f
+  md5: b64523fb87ac6f87f0790f324ad43046
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 312472
+  timestamp: 1744330953241
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.5.2-h86ecc28_0.conda
+  sha256: c887543068308fb0fd50175183a3513f60cd8eb1defc23adc3c89769fde80d48
+  md5: 44b2cfec6e1b94723a960f8a5e6206ae
+  depends:
+  - libgcc >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 357115
+  timestamp: 1744331282621
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+  sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
+  md5: 70e3400cbbfa03e96dcde7fc13e38c7b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 28424
+  timestamp: 1749901812541
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
+  sha256: 7641dfdfe9bda7069ae94379e9924892f0b6604c1a016a3f76b230433bb280f2
+  md5: 5044e160c5306968d956c2a0a2a440d6
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 29512
+  timestamp: 1749901899881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.49-h943b412_0.conda
+  sha256: c8f5dc929ba5fcee525a66777498e03bbcbfefc05a0773e5163bb08ac5122f1a
+  md5: 37511c874cf3b8d0034c8d24e73c0884
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 289506
+  timestamp: 1750095629466
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.49-hec79eb8_0.conda
+  sha256: d9b2e2c1b47ea8889fa4407ad2ffbf6388b9608031a98acd9f9876d0b15a20cc
+  md5: a665eccfe09f815de0cdda657598a5b3
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  size: 293525
+  timestamp: 1750097792167
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
+  sha256: 2dbcef0db82e0e7b6895b6c0dadd3d36c607044c40290c7ca10656f3fca3166f
+  md5: 6458be24f09e1b034902ab44fe9de908
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - openldap >=2.6.9,<2.7.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: PostgreSQL
+  size: 2680582
+  timestamp: 1746743259857
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.5-hf590da8_0.conda
+  sha256: 36db4c66ca15337d1077d1490064e04a1a705f393a8d0577aea9b4ffee604129
+  md5: b5a01e5aa04651ccf5865c2d029affa3
+  depends:
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - openldap >=2.6.9,<2.7.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: PostgreSQL
+  size: 2677495
+  timestamp: 1746743322764
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+  sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
+  md5: ab0bff36363bec94720275a681af8b83
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2945348
+  timestamp: 1728565355702
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
+  sha256: d8c7b6f851bfc53494d9b8e54d473c4f11ab26483a6e64df6f7967563df166b1
+  md5: 538dbe0ad9f248e2e109abb9b6809ea5
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2802876
+  timestamp: 1728564881988
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.4-h9969a89_0.conda
+  sha256: 96bbd009b3d7f82e9af37e980af9285431ecd5c6f098a0f1afe0021d8d02b88a
+  md5: e4fdd13a67d5b30459463e925b9e7e1f
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - _openmp_mutex >=4.5
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - jasper >=4.2.5,<5.0a0
+  - lcms2 >=2.17,<3.0a0
+  license: LGPL-2.1-only
+  size: 704665
+  timestamp: 1744641234631
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libraw-0.21.4-h74ffddf_0.conda
+  sha256: 98360c0fce61f693afad344b55835ca9a8c8344434511676623c5c642ad67d96
+  md5: 1723d3fd7b6ed1fdefd4f20e0d3c3079
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - _openmp_mutex >=4.5
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - jasper >=4.2.5,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lcms2 >=2.17,<3.0a0
+  license: LGPL-2.1-only
+  size: 742040
+  timestamp: 1744641244231
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+  sha256: a45ef03e6e700cc6ac6c375e27904531cf8ade27eb3857e080537ff283fb0507
+  md5: d27665b20bc4d074b86e628b3ba5ab8b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=11.0.0,<12.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libxml2 >=2.13.7,<2.14.0a0
+  - pango >=1.56.3,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  size: 6543651
+  timestamp: 1743368725313
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h3ac5bce_3.conda
+  sha256: e305cf09ec904625a66c7db1305595691c633276b7e34521537cef88edc5249a
+  md5: b115c14b3919823fbe081366d2b15d86
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - freetype >=2.13.3,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=11.0.0,<12.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libxml2 >=2.13.7,<2.14.0a0
+  - pango >=1.56.3,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  size: 6274749
+  timestamp: 1743376660664
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.3.0-he8ea267_2.conda
+  sha256: 27c4c8bf8e2dd60182d47274389be7c70446df6ed5344206266321ee749158b4
+  md5: 2b6cdf7bb95d3d10ef4e38ce0bc95dba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13.3.0
+  - libstdcxx >=13.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 4155341
+  timestamp: 1740240344242
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-13.3.0-ha58e236_2.conda
+  sha256: 7c1151a33874786be51279b6ae23309167dbf4373d6e69dc61545622c591b5ab
+  md5: 3ddd8f545e5f25c625e54d342501a336
+  depends:
+  - libgcc >=13.3.0
+  - libstdcxx >=13.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 4156159
+  timestamp: 1740241051716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+  sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
+  md5: ef1910918dd895516a769ed36b5b3a4e
+  depends:
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 354372
+  timestamp: 1695747735668
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
+  md5: ad8e62c0faec46b1442f960489c80b49
+  depends:
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 396501
+  timestamp: 1695747749825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.2-h6cd9bfd_0.conda
+  sha256: 07649c7c19b916179926006df5c38074618d35bf36cd33ab3fe8b22182bbd258
+  md5: b04c7eda6d7dab1e6503135e7fad4d25
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 918887
+  timestamp: 1751135622316
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.50.2-he2a92bd_0.conda
+  sha256: 031499486870fa097445e660e3f1e94ba1e6c0dd063c9b1513be2ba5bff00472
+  md5: d9c2f664f026418134d24a288eec2acd
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 918088
+  timestamp: 1751135654429
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+  md5: eecce068c7e4eddeb169591baac20ac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 304790
+  timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+  sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+  md5: eecc495bcfdd9da8058969656f916cc2
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 311396
+  timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+  sha256: 7650837344b7850b62fdba02155da0b159cf472b9ab59eb7b472f7bd01dff241
+  md5: 6d11a5edae89fe413c0569f16d308f5a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3896407
+  timestamp: 1750808251302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_3.conda
+  sha256: 916a8c2530992140d23c4d3f63502f250ff36df7298ed9a8b72d3629c347d4ce
+  md5: 4e2d5a407e0ecfe493d8b2a65a437bd8
+  depends:
+  - libgcc 15.1.0 he277a41_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3833339
+  timestamp: 1750808947966
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-13.3.0-hc03c837_102.conda
+  sha256: abc89056d4ca7debe938504b3b6d9ccc6d7a0f0b528fe3409230636a21e81002
+  md5: aa38de2738c5f4a72a880e3d31ffe8b4
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 12873130
+  timestamp: 1740240239655
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-13.3.0-h0c07274_102.conda
+  sha256: e0e58bf0ee5b29b453bf8645c9a5ce261521cc977ee2bfda47e79ee01a961628
+  md5: c78537689a8d6ccddb3027e463e89a09
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 11882360
+  timestamp: 1740240875298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
+  sha256: bbaea1ecf973a7836f92b8ebecc94d3c758414f4de39d2cc6818a3d10cb3216b
+  md5: 57541755b5a51691955012b8e197c06c
+  depends:
+  - libstdcxx 15.1.0 h8f9b012_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29093
+  timestamp: 1750808292700
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.1.0-hf1166c9_3.conda
+  sha256: cb93360dce004fda2f877fd6071c8c0d19ab67b161ff406d5c0d63b7658ad77c
+  md5: f981af71cbd4c67c9e6acc7d4cc3f163
+  depends:
+  - libstdcxx 15.1.0 h3f4de04_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 29078
+  timestamp: 1750808974598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
+  sha256: e26b22c0ae40fb6ad4356104d5fa4ec33fe8dd8a10e6aef36a9ab0c6a6f47275
+  md5: 1e12c8aa74fa4c3166a9bdc135bc4abf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.1,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  size: 487969
+  timestamp: 1750949895969
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-257.7-h2bb824b_0.conda
+  sha256: 35ecfc98c22d4f035b051fe72398206607d48944e7bd4f60431e63eb95538e0d
+  md5: 63b49a2d12a1739f72be430c2ed58727
+  depends:
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  - libgcrypt-lib >=1.11.1,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: LGPL-2.1-or-later
+  size: 510879
+  timestamp: 1750949944203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtheora-1.1.1-h4ab18f5_1006.conda
+  sha256: 50c8cd416ac8425e415264de167b41ae8442de22a91098dfdd993ddbf9f13067
+  md5: 553281a034e9cf8693c9df49f6c78ea1
+  depends:
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.5,<1.4.0a0
+  - libvorbis 1.3.*
+  - libvorbis >=1.3.7,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 328924
+  timestamp: 1719667859099
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtheora-1.1.1-h68df207_1006.conda
+  sha256: b5a46b5f2cf1ab6734dcab65f370c6b95f1d62ed27d9d30fe06a828bcb9b239b
+  md5: 5786518d6e1eff2225fe56c0e5d573d8
+  depends:
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.5,<1.4.0a0
+  - libvorbis 1.3.*
+  - libvorbis >=1.3.7,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 335103
+  timestamp: 1719667812650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
+  sha256: 7fa6ddac72e0d803bb08e55090a8f2e71769f1eb7adbd5711bdd7789561601b1
+  md5: e79a094918988bb1807462cd42c83962
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 429575
+  timestamp: 1747067001268
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-h7c15681_5.conda
+  sha256: 4b2c6f5cd5199d5e345228a0422ecb31a4340ff69579db49faccba14186bb9a2
+  md5: 264a9aac20276b1784dac8c5f8d3704a
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=13
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 466229
+  timestamp: 1747067015512
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
+  sha256: 3fca2655f4cf2ce6b618a2b52e3dce92f27f429732b88080567d5bbeea404c82
+  md5: 5a23e52bd654a5297bd3e247eebab5a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 143533
+  timestamp: 1750949902296
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libudev1-257.7-h7b9e449_0.conda
+  sha256: 8c9847a934e251479f343f0be3b771836cdccfcf132145bd2da34946acd01988
+  md5: d19d804623b40d7ab5f807c240b4caaf
+  depends:
+  - libcap >=2.75,<2.76.0a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 154447
+  timestamp: 1750949949664
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.6.2-h9c3ff4c_0.tar.bz2
+  sha256: f2ac872920833960e514ce9efd8f7c08ce66dd870738d73839d1bce1ac497de6
+  md5: a730b2badd586580c5752cc73842e068
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 75491
+  timestamp: 1638450786937
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunwind-1.6.2-h01db608_0.tar.bz2
+  sha256: 7862d36ffc9f6b2ed3381ce77c78b9e5691d7353a19dd2050630868e192adf6f
+  md5: 93b7bbf9099cfe09e67c0abe34bb7885
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 90479
+  timestamp: 1638452154070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.10-h84d6215_0.conda
+  sha256: d1922de78ead6a9d19b7a4f82cf1fff7332e9012fd9968aa835c89888628d3d7
+  md5: 1a11973f25f6168f4f6a65883cf7bb2a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 124944
+  timestamp: 1748686602857
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liburing-2.10-h17cf362_0.conda
+  sha256: 658d4138e5cd76794c81c3561361fd9d2091c9a13a329cb5b61a83371feeef4e
+  md5: 49a98ebf80bbc4661df8a26706d8b3b5
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 126811
+  timestamp: 1748687566969
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+  sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
+  md5: d17e3fb595a9f24fa9e149239a33475d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libudev1 >=257.4
+  license: LGPL-2.1-or-later
+  size: 89551
+  timestamp: 1748856210075
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libusb-1.0.29-h06eaf92_0.conda
+  sha256: a60aae6b529cd7caa7842f9781ef95b93014e618f71fb005e404af434d76a33f
+  md5: 9a86e7473e16fe25c5c47f6c1376ac82
+  depends:
+  - libgcc >=13
+  - libudev1 >=257.4
+  license: LGPL-2.1-or-later
+  size: 93129
+  timestamp: 1748856228398
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+  sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
+  md5: 000e30b09db0b7c775b21695dff30969
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35720
+  timestamp: 1680113474501
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb9d3cd8_0.conda
+  sha256: 770ca175d64323976c9fe4303042126b2b01c1bd54c8c96cafeaba81bdb481b8
+  md5: 1349c022c92c5efd3fd705a79a5804d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 890145
+  timestamp: 1748304699136
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.51.0-h86ecc28_0.conda
+  sha256: 2b3811ac29005edb63b85e4eb24d13e04b93e3c9b33dcb11b11a11681af0665d
+  md5: bd76e353d6a09ae834fc9056343f2f73
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 645133
+  timestamp: 1748304599853
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h4f16b4b_2.conda
+  sha256: e0df324fb02fa05a05824b8db886b06659432b5cff39495c59e14a37aa23d40f
+  md5: 2c65566e79dc11318ce689c656fb551c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglx >=1.7.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - wayland-protocols
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 217567
+  timestamp: 1740897682004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+  sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
+  md5: 309dec04b70a3cc0f1e84a4013683bc0
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 286280
+  timestamp: 1610609811627
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
+  md5: c2863ff72c6d8a59054f8b9102c206e9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 292082
+  timestamp: 1610616294416
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+  sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
+  md5: cde393f461e0c169d9ffb2fc70f81c33
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1022466
+  timestamp: 1717859935011
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
+  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1211700
+  timestamp: 1717859955539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
+  sha256: c45283fd3e90df5f0bd3dbcd31f59cdd2b001d424cf30a07223655413b158eaf
+  md5: 63f790534398730f59e1b899c3644d4a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 429973
+  timestamp: 1734777489810
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.5.0-h0886dbf_0.conda
+  sha256: b3d881a0ae08bb07fff7fa8ead506c8d2e0388733182fe4f216f3ec5d61ffcf0
+  md5: 95ef4a689b8cc1b7e18b53784d88f96b
+  depends:
+  - libgcc >=13
+  constrains:
+  - libwebp 1.5.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 362623
+  timestamp: 1734779054659
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+  md5: cd14ee5cca2464a425b1dbfc24d90db2
+  depends:
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  size: 397493
+  timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
+  md5: b4df5d7d4b63579d081fd3a4cf99740e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 114269
+  timestamp: 1702724369203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.10.0-h65c71a3_0.conda
+  sha256: a8043a46157511b3ceb6573a99952b5c0232313283f2d6a066cec7c8dcaed7d0
+  md5: fedf6bfe5d21d21d2b1785ec00a8889a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 707156
+  timestamp: 1747911059945
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.10.0-hbab7b08_0.conda
+  sha256: 620f16864f4f9d7181d89fa4266dba0b18cb9bca72f930500cf9307e549e4247
+  md5: 36cd1db31e923c6068b7e0e6fce2cd7b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 719116
+  timestamp: 1747911079432
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.8-h4bc477f_0.conda
+  sha256: b0b3a96791fa8bb4ec030295e8c8bf2d3278f33c0f9ad540e73b5e538e6268e7
+  md5: 14dbe05b929e329dbaa6f2d0aa19466d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 690864
+  timestamp: 1746634244154
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.8-he060846_0.conda
+  sha256: b453be503923e213ce5132de0b2e2bc89549d742dcc403acba8dcc4a0ced740c
+  md5: c73dfe6886cc8d39a09c357a36f91fb2
+  depends:
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 733785
+  timestamp: 1746634366734
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
+  sha256: 684e9b67ef7b9ca0ca993762eeb39705ec58e2e7f958555c758da7ef416db9f3
+  md5: e71f31f8cfb0a91439f2086fc8aa0461
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.1,<2.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 254297
+  timestamp: 1701628814990
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxslt-1.1.39-h1cc9640_0.conda
+  sha256: 89ce87b5f594b2ddcd3ddf66dd3f36f85bbe3562b3f408409ccec787d7ed36a3
+  md5: 13e1d3f9188e85c6d59a98651aced002
+  depends:
+  - libgcc-ng >=12
+  - libxml2 >=2.12.1,<2.14.0a0
+  license: MIT
+  license_family: MIT
+  size: 260979
+  timestamp: 1701628809171
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+  sha256: 991e7348b0f650d495fb6d8aa9f8c727bdf52dabf5853c0cc671439b160dce48
+  md5: a7b27c075c9b7f459f1c022090697cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 109043
+  timestamp: 1730442108429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzip-1.11.2-h3e8f909_0.conda
+  sha256: 9ae7edbe6dcdaa0371736118a1e05ffa47c15c0118a092ff1b0a35cbb621ac2d
+  md5: faf7adbb1938c4aa7a312f110f46859b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117603
+  timestamp: 1730442215935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
+  md5: 08aad7cbe9f5a6b460d0976076b6ae64
+  depends:
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 66657
+  timestamp: 1727963199518
+- conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+  sha256: e4a07f357a4cf195a2345dabd98deab80f4d53574abe712a9cc7f22d3f2cc2c3
+  md5: 49647ac1de4d1e4b49124aedf3934e02
+  depends:
+  - __unix
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 59696
+  timestamp: 1746634858826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py311hbd2c71b_0.conda
+  sha256: 0c8783524bd51f8e9d6ec1322e74fdd200036e994b331d8a37aa28759e15b595
+  md5: 3fee70825164281b54d6c3aba97e619c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1584583
+  timestamp: 1751021744404
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lxml-6.0.0-py311h3bfafd0_0.conda
+  sha256: 1c35d2a173a124f23a49bdfbc886e235f513e7d8725d078ffaaa11e0087f9b66
+  md5: cc20451aa5850597163e676b7f555426
+  depends:
+  - libgcc >=13
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libxslt >=1.1.39,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause and MIT-CMU
+  size: 1509994
+  timestamp: 1751021756656
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+  sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
+  md5: 9de5350a85c4a20c685259b889aa6393
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 167055
+  timestamp: 1733741040117
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
+  sha256: 67e55058d275beea76c1882399640c37b5be8be4eb39354c94b610928e9a0573
+  md5: 6654e411da94011e8fbe004eacb8fe11
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 184953
+  timestamp: 1733740984533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+  sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+  md5: 33405d2a66b1411db9f7242c8b97c9e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 513088
+  timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+  sha256: d243aea768e6fa360b7eda598340f43d2a41c9fc169d9f97f505410be68815f8
+  md5: 5983ffb12d09efc45c4a3b74cd890137
+  depends:
+  - libgcc >=13
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 528318
+  timestamp: 1727801707353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.3-py311h2b939e6_0.conda
+  sha256: 39e54c0b54c374c9b27e4ba5dcf78220ce346007c39be9c83441f1eb4a4e33f1
+  md5: 0d1b7dfe2bbf983cb7907f6cbd6613e6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8302117
+  timestamp: 1746820694094
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.10.3-py311h0385ec1_0.conda
+  sha256: b1a2cf03aeac3b5d0fd6adc6425ae89382e9b3191e56bb74269c713725a245bb
+  md5: 12e13b027ccad56f7af4ece1e557a6e9
+  depends:
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.7
+  - python_abi 3.11.* *_cp311
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 8354290
+  timestamp: 1746820865481
+- conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
+  sha256: 9b0037171dad0100f0296699a11ae7d355237b55f42f9094aebc0f41512d96a1
+  md5: 827064ddfe0de2917fb29f1da4f8f533
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 12934
+  timestamp: 1733216573915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+  sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
+  md5: c7f302fd11eeb0987a6a5e1f3aed6a21
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 491140
+  timestamp: 1730581373280
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
+  sha256: d65d5a00278544639ba4f99887154be00a1f57afb0b34d80b08e5cba40a17072
+  md5: cdf140c7690ab0132106d3bc48bce47d
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 558708
+  timestamp: 1730581372400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hd18a35c_0.conda
+  sha256: f07aafd9e9adddf66b75630b4f68784e22ce63ae9e0887711a7386ceb2506fca
+  md5: d0898973440adc2ad25917028669126d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 103109
+  timestamp: 1749813330034
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/msgpack-python-1.1.1-py311hc07b1fb_0.conda
+  sha256: 095aa65ae7fb42c6aa165b572f3e2c709ff3c9f46ce07492b3f698305018a0ae
+  md5: f5e9ada9ace7830258a1fe01e4e4043a
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 100520
+  timestamp: 1749813396402
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.0-py311h2dc5d0c_0.conda
+  sha256: cdcd777ba2a05c4ff712163fc993a0fcbb7bac5d0ecc3387cc5eb4003a5ca78e
+  md5: 3449609f67d69013f02277539f72d449
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  size: 96796
+  timestamp: 1751089505587
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/multidict-6.6.0-py311h58d527c_0.conda
+  sha256: 84f9fc8db6adeea14877c02817885319870118c67e4359a3a8931dd9d1997138
+  md5: bc270bd9633cbaa96da96b5358044bb4
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  size: 98456
+  timestamp: 1751089546765
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+  md5: 37293a85a0f4f77bbd9cf7aaefc62609
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  size: 15851
+  timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.3.0-h266115a_0.conda
+  sha256: 09008f1b5b8af97e56e1613af09bd6c3cc4fe0c5c3d23f382bf4dc58f5e09163
+  md5: 9693774d2822c39a9541f2a80c346e30
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.5.0,<4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 635956
+  timestamp: 1745255372098
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.3.0-h3f5c77f_0.conda
+  sha256: bd1bd50e845612bfe3ddc8dc22a8f62f378667dab2945ea24bef9ec0f3f6df3c
+  md5: c25d76d0599997467dcb79542801429c
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.5.0,<4.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 648085
+  timestamp: 1745255843850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.3.0-he0572af_0.conda
+  sha256: 3367465235edea7c78ea0d4e7155171b03bf05f2a7c25cdecf62821de604810e
+  md5: 5eb3dd8ccc96213c0961a2bba1f611d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.3.0 h266115a_0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1369861
+  timestamp: 1745255447998
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.3.0-h11569fd_0.conda
+  sha256: 19bb87040fc1f91234ced37153d2204ad83eea9e44e805bd16dfe304aec5bd3a
+  md5: 9c30dc31b2c1a7c8c417f4b53db8ce1b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.3.0 h3f5c77f_0
+  - openssl >=3.5.0,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1409341
+  timestamp: 1745255909247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
+  sha256: 91cfb655a68b0353b2833521dc919188db3d8a7f4c64bea2c6a7557b24747468
+  md5: 182afabe009dc78d8b73100255ee6868
+  depends:
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  size: 926034
+  timestamp: 1738196018799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netifaces-0.11.0-py311h9ecbd09_3.conda
+  sha256: 3cac2f9846f824b5dec81898b5d295b7ab69c8d88fb00ba4967119ded05d22bf
+  md5: a838f1ff02af237e3d600fefc286558b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 19638
+  timestamp: 1735935203437
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/netifaces-0.11.0-py311ha879c10_3.conda
+  sha256: c87fb7d7fd9fe846cb985805c2286cd49d522e81ec394472dbfa30add25ce9fb
+  md5: 7604a49bf7a42ea47e87bd967e397e93
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 20535
+  timestamp: 1735935375626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.13.0-h7aa8ee6_0.conda
+  sha256: 8cf09470430b5aba5165c7aefed070d2c8f998f69fede01197ef838bf17fa81a
+  md5: 2f67cb5c5ec172faeba94348ae8af444
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 180917
+  timestamp: 1750273173789
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.13.0-ha6136e2_0.conda
+  sha256: 28f902fe5eb5d9194222a0c05ed2f8accf02e23438d83b719ef6cc09e5805660
+  md5: 26b19c4e579cee6a711be9e29ee2459f
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 180031
+  timestamp: 1750273180955
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
+  sha256: e2fc624d6f9b2f1b695b6be6b905844613e813aa180520e73365062683fe7b49
+  md5: d76872d096d063e226482c99337209dc
+  license: MIT
+  license_family: MIT
+  size: 135906
+  timestamp: 1744445169928
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h5ad3122_0.conda
+  sha256: ba0e4e4f0b0b7fa1f7b7e3abe95823daf915d73ddd976e73a5f9ade2060760dd
+  md5: 92016ee90e17c57a1d2f47333d4bc92f
+  license: MIT
+  license_family: MIT
+  size: 136733
+  timestamp: 1744445179648
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+  sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
+  md5: de9cd5bca9e4918527b9b72b6e2e1409
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 230204
+  timestamp: 1729545773406
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+  sha256: 404a4ec0430fbdce53fee00d9acf9f307aa9b3a6d06b5696c38ca3f92195a490
+  md5: 6170d131ea39ca6e8f6695507c9d3388
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 235389
+  timestamp: 1729545760194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.113-h159eef7_0.conda
+  sha256: ceef2b561cc92f00bac1263562f8fd9c17ff11de710fc27370572adee1b34b1c
+  md5: 47fbbbda15a2a03bae2b3d2cd3735b30
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite >=3.50.1,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2009636
+  timestamp: 1750369586316
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.113-h7e26b49_0.conda
+  sha256: 220dbf2856433554b46656f8249375c248505f727a62eed87973b5f034096eeb
+  md5: 8a1771cc7d612b2e20579603ce59e574
+  depends:
+  - libgcc >=13
+  - libsqlite >=3.50.1,<4.0a0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 1996621
+  timestamp: 1750373050362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+  sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
+  md5: a502d7aad449a1206efb366d6a12c52d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8065890
+  timestamp: 1707225944355
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py311h69ead2a_0.conda
+  sha256: 88800a1d9d11c2fccab09d40d36f7001616f5119eaf0ec86186562f33564e651
+  md5: 3fd00dd400c8d3f9da12bf33061dd28d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7234391
+  timestamp: 1707225781489
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+  sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
+  md5: 56f8947aa9d5cf37b0b3d43b83f34192
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - opencl-headers >=2024.10.24
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106742
+  timestamp: 1743700382939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+  sha256: 2b6ce54174ec19110e1b3c37455f7cd138d0e228a75727a9bba443427da30a36
+  md5: 45c3d2c224002d6d0d7769142b29f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55357
+  timestamp: 1749853464518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.4-h2cd1444_0.conda
+  sha256: 91f2d6bee02f1ad876f2d2f7e4cd00993b77513b460b395672bde04c7ef3e7fb
+  md5: e10f915be2fee16e00d314ae406c983b
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - imath >=3.1.12,<3.1.13.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1319519
+  timestamp: 1749538914449
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.4-h718fb27_0.conda
+  sha256: 4589b3b4ec36f91a207710a9a361bb13630398525aaf2b0fba6729cfde3f4205
+  md5: f1fb80b82a8c8601ab3704cae1a8d112
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.24,<1.25.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1275966
+  timestamp: 1749538949582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.5.0-hf92e6e3_0.conda
+  sha256: dedda20c58aec3d8f9c12e3660225608b93a257a21e0da703fdd814789291519
+  md5: d1b18a73fc3cfd0de9c7e786d2febb8f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 727504
+  timestamp: 1731068122274
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.5.0-h6c5ec6d_0.conda
+  sha256: 1e9623c4cb34d1f8b43884c629cb61ddbe8dfbdf03f6043ec9a772c12b6867ed
+  md5: d9407eab893d3bbf706d8ede547ae639
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 785332
+  timestamp: 1731068180758
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
+  sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
+  md5: 9e5816bc95d285c115a3ebc2f8563564
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 342988
+  timestamp: 1733816638720
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.3-h3f56577_0.conda
+  sha256: 92d310033e20538e896f4e4b1ea4205eb6604eee7c5c651c4965a0d8d3ca0f1d
+  md5: 04231368e4af50d11184b50e14250993
+  depends:
+  - libgcc >=13
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 377796
+  timestamp: 1733816683252
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
+  sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
+  md5: 2e5bf4f1da39c0b32778561c3c4e5878
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cyrus-sasl >=2.1.27,<3.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.5.0,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  size: 780253
+  timestamp: 1748010165522
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
+  sha256: 13c7ba058b6e151468111235218158083b9e867738e66a5afb96096c5c123348
+  md5: 48f31a61be512ec1929f4b4a9cedf4bd
+  depends:
+  - cyrus-sasl >=2.1.27,<3.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - openssl >=3.5.0,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  size: 902902
+  timestamp: 1748010210718
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
+  md5: de356753cfdbffcde5bb1e86e3aa6cd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 3117410
+  timestamp: 1746223723843
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.5.0-hd08dc88_1.conda
+  sha256: 58120daf06a52ba203f94eccb43900213a9f2b3cc310bbaa868505ccd7afbdaa
+  md5: ee68fdc3a8723e9c58bdd2f10544658f
+  depends:
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 3642633
+  timestamp: 1746225726804
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orocos-kdl-1.5.1-h5888daf_8.conda
+  sha256: 2c32fc459cabed3b272b3d41c63a869de3bee69636dee39519005fbc3e9c7b64
+  md5: 81554d1604c59c8eabf592eacd1f561a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - eigen
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 388297
+  timestamp: 1729197896717
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orocos-kdl-1.5.1-h5ad3122_8.conda
+  sha256: 8f5c6dce2c01310f98fcfb4d5ce58c9deac705673be86c21c33c4a2e1b3b4710
+  md5: c1ae5b9ea5ec8f760127f6c5e1ebc565
+  depends:
+  - eigen
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 368402
+  timestamp: 1729198046581
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+  sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
+  md5: 58335b26c38bf4a20f399384c33cbcf9
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 62477
+  timestamp: 1745345660407
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.3-h9ac818e_1.conda
+  sha256: 9c00bbc8871b9ce00d1a1f0c1a64f76c032cf16a56a28984b9bb59e46af3932d
+  md5: 21899b96828014270bd24fd266096612
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=11.0.0,<12.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 453100
+  timestamp: 1743352484196
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.3-h1e6a6fd_1.conda
+  sha256: 85f3863d264c28665e43c3084ff93273f93b67637c4b28aa8d3645d789e27a33
+  md5: bc1598700c29f7d1fe8e3218acef401e
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.13.3,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=11.0.0,<12.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 465939
+  timestamp: 1743354615490
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcl-1.14.1-h679aaff_7.conda
+  sha256: 95545e4cc2bc68b32daba2b088518122205c40d9386528e986449f88bfc63921
+  md5: 4e48d8882cd824adc56e8e29acdc2517
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - flann >=1.9.2,<1.9.3.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - qhull >=2020.2,<2020.3.0a0
+  - qt6-main >=6.8.1,<6.9.0a0
+  - vtk * qt*
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18152103
+  timestamp: 1736289491897
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcl-1.14.1-h29e8f2a_7.conda
+  sha256: 5d1bd7633cfaa60ab23e67e110ad281cdaf8369e4215db0cea054b762cfcd913
+  md5: e643e288c3e5c31dc8f5bcf31bfc6ee9
+  depends:
+  - flann >=1.9.2,<1.9.3.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libstdcxx >=13
+  - qhull >=2020.2,<2020.3.0a0
+  - qt6-main >=6.8.1,<6.9.0a0
+  - vtk * qt*
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17630435
+  timestamp: 1736290171388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
+  sha256: 8f35c244b1631a4f31fb1d66ab6e1d9bfac0ca9b679deced1112c7225b3ad138
+  md5: c05d1820a6d34ff07aaaab7a9b7eddaa
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259377
+  timestamp: 1623788789327
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre-8.45-h01db608_0.tar.bz2
+  sha256: 7a6062de76f695f6d8f0ddda0ff171e4b47e2b863d6012def440c7703aea0069
+  md5: 3963d9f84749d6cdba1f12c65967ccd1
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 249883
+  timestamp: 1623793306266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
+  sha256: 27c4014f616326240dcce17b5f3baca3953b6bc5f245ceb49c3fa1e6320571eb
+  md5: b90bece58b4c2bf25969b70f3be42d25
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1197308
+  timestamp: 1745955064657
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.45-hf4ec17f_0.conda
+  sha256: d5aecfcb64514719600e35290cc885098dbfef8e9c037eea6afc43d1acc65c2e
+  md5: ad22a9a9497f7aedce73e0da53cd215f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1134832
+  timestamp: 1745955178803
+- conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  md5: d94aa03d99d8adc9898f783eba0d84d2
+  depends:
+  - python >=3.8
+  - tomli
+  license: MIT
+  license_family: MIT
+  size: 19044
+  timestamp: 1667916747996
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
+  sha256: 35ad7e1a9fe8152d0bad51046490c3903d7c56e06a1ba2a0af5be4fd3bdc18c7
+  md5: 4c49bdabd1d4e09386dabc676fb6bd65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 43489672
+  timestamp: 1746646364323
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.2.1-py311ha4eaa5e_0.conda
+  sha256: b01558b6c06db0754da0ed1dfa9d069cd99fa3849aa10c0ba179abccc2eb7102
+  md5: 580e0d3c80c27c4f3997ad094dc9f127
+  depends:
+  - lcms2 >=2.17,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.3,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 42601207
+  timestamp: 1746648100320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
+  sha256: 6cb261595b5f0ae7306599f2bb55ef6863534b6d4d1bc0dcfdfa5825b0e4e53d
+  md5: 39b4228a867772d610c02e06f939a5b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 402222
+  timestamp: 1749552884791
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.2-h86a87f0_0.conda
+  sha256: df60bb320bbec8df804780c0310b471478a245192c16568769fc96269ce15445
+  md5: 019114cf59c0cce5a08f6661179a1d65
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 310404
+  timestamp: 1749554318638
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+  sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
+  md5: 1bee70681f504ea424fb07cdb090c001
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 115175
+  timestamp: 1720805894943
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hce167ba_1009.conda
+  sha256: 6468cbfaf1d3140be46dd315ec383d373dbbafd770ce2efe77c3f0cdbc4576c1
+  md5: 05eda637f6465f7e8c5ab7e341341ea9
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 54834
+  timestamp: 1720806008171
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
+  sha256: a8eb555eef5063bbb7ba06a379fa7ea714f57d9741fe0efdb9442dbbc2cccbcc
+  md5: 7da7ccd349dbf6487a7778579d2bb971
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 24246
+  timestamp: 1747339794916
+- conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+  sha256: bae453e5cecf19cab23c2e8929c6e30f4866d996a8058be16c797ed4b935461f
+  md5: fd5062942bfa1b0bd5e0d2a4397b099e
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49052
+  timestamp: 1733239818090
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.5.1-h0054346_0.conda
+  sha256: 835afb9c8198895ec1ce2916320503d47bb0c25b75c228d744c44e505f1f4e3b
+  md5: 398cabfd9bd75e90d0901db95224f25f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3108751
+  timestamp: 1733138115896
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.5.1-h9655f4d_0.conda
+  sha256: f1cf12e3f3101e3b5eec136b54d71c11dd8a9408f2574d1e0c8307908e0461d0
+  md5: 60cc005fa3ce97967d435f92adfc7cf7
+  depends:
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libsqlite >=3.47.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3038717
+  timestamp: 1733139312143
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py311h2dc5d0c_0.conda
+  sha256: 38ef315508a4c6c96985a990b172964a8ed737fe4e991d82ad9d2a77c45add1f
+  md5: c75eb8c91d69fe0385fce584f3ce193a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54558
+  timestamp: 1744525097548
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/propcache-0.3.1-py311h58d527c_0.conda
+  sha256: 65d0f979c9f3e3972dc8ef178c5fbb0bf6858cd82521ec9e6be5b563c18756c3
+  md5: 872b336081fdbcd407ba6eef96f6651a
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54289
+  timestamp: 1744525129299
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h9ecbd09_0.conda
+  sha256: 50d0944b59a9c6dfa6b99cc2632bf8bc9bef9c7c93710390ded6eac953f0182d
+  md5: 1a390a54b2752169f5ba4ada5a8108e4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 484778
+  timestamp: 1740663319335
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.0.0-py311ha879c10_0.conda
+  sha256: 4f1c5c7fa18d0e5d917b80305f5df4a8d3563457b77cb943023b72556d27544e
+  md5: 4ac9b5671a4ed4d8966ec65fca25f0b4
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 483797
+  timestamp: 1740663303350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8252
+  timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+  md5: bb5a90c93e3bac3d5690acf76b4a6386
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 8342
+  timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+  sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
+  md5: 2c97dd90633508b422c11bd3018206ab
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 114871
+  timestamp: 1696182708943
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
+  md5: 9af93a191056b12e841b7d32f1b01b1c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 110831
+  timestamp: 1696182637281
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
+  sha256: d2377bb571932f2373f593b7b2fc3b9728dc6ae5b993b1b65d7f2c8bb39a0b49
+  md5: 66b1fa9608d8836e25f9919159adc9c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=257.4
+  - libxcb >=1.17.0,<2.0a0
+  constrains:
+  - pulseaudio 17.0 *_1
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 764231
+  timestamp: 1742507189208
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h2f84921_1.conda
+  sha256: 0294728d0a2fc0bdfbcfda98b7ada2d8bb420f76c944fa041ece4140858c2ee5
+  md5: a617203ec445f510a3a8651810c735e0
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=257.4
+  - libxcb >=1.17.0,<2.0a0
+  constrains:
+  - pulseaudio 17.0 *_1
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 763814
+  timestamp: 1742507234837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.10.0-qt6_py311h9d93fc6_613.conda
+  sha256: e631ad9c1742e6ea5d41aece80b87aa28567e82bafb7a82a161732af88008f78
+  md5: edcf54ea29c026f4bf1604426dcceb27
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libopencv 4.10.0 qt6_py311h8702e32_613
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 1152865
+  timestamp: 1734359020888
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.10.0-headless_py311h41de8d1_13.conda
+  sha256: 4ed56d75834354b7b16e312ae7c783f50833b2da7c394d2b548f895a8023ac64
+  md5: ac1b020c9fd8b26b5b8baed1dd72bc4f
+  depends:
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - libopencv 4.10.0 headless_py311h285173e_13
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 1153638
+  timestamp: 1734362551352
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-2.13.6-pyhc790b64_3.conda
+  sha256: d429f6f255fbe49f09b9ae1377aa8cbc4d9285b8b220c17ae2ad9c4894c91317
+  md5: 1594696beebf1ecb6d29a1136f859a74
+  depends:
+  - pybind11-global 2.13.6 *_3
+  - python >=3.9
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 186821
+  timestamp: 1747935138653
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+  sha256: d4fb485b79b11042a16dc6abfb0c44c4f557707c2653ac47c81e5d32b24a3bb0
+  md5: 878f923dd6acc8aeb47a75da6c4098be
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9906
+  timestamp: 1610372835205
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-2.13.6-pyh217bc35_3.conda
+  sha256: c044cfcbe6ef0062d0960e9f9f0de5f8818cec84ed901219ff9994b9a9e57237
+  md5: 730a5284e26d6bdb73332dafb26aec82
+  depends:
+  - __unix
+  - python >=3.9
+  constrains:
+  - pybind11-abi ==4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 180116
+  timestamp: 1747934418811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pybullet-3.25-py311h2ed89a0_4.conda
+  sha256: 91586c22571d410403c0161b5cd5e6904a9301ac1a32346d006add5a213fb633
+  md5: e42dc8e97f016935a2f86a420a8ad568
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bullet-cpp 3.25 h7db5c69_4
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Zlib
+  size: 62898751
+  timestamp: 1747516495240
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pybullet-3.25-py311h7b00dee_4.conda
+  sha256: d6206b7377ddce51a279cb16bdd8cea1ef312f04eba752c62b3bed63fde47a40
+  md5: f4b0192b18ac38b8e72471309af678a6
+  depends:
+  - bullet-cpp 3.25 py311h848c333_4
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Zlib
+  size: 63342267
+  timestamp: 1747516698760
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.28.0-py311hd785cd9_0.conda
+  sha256: 793b7c0ac01659b3c6c94e645af82dfdfdf38362541932a01ad2b89a0599505d
+  md5: 25e7689a20f93528204330c11075928b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-only OR MPL-1.1
+  size: 117823
+  timestamp: 1744682534075
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pycairo-1.28.0-py311h0c1bbf2_0.conda
+  sha256: d28dfec4ff76590a4079480b3d8f3b64c7de08900b650bdf8a7071dec52fd13c
+  md5: 24d76f41630c579ff6778535df67d551
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LGPL-2.1-only OR MPL-1.1
+  size: 121202
+  timestamp: 1744684213740
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
+  sha256: 1950f71ff44e64163e176b1ca34812afc1a104075c3190de50597e1623eb7d53
+  md5: 85815c6a22905c080111ec8d56741454
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 35182
+  timestamp: 1750616054854
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 110100
+  timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
+  sha256: 83ab8434e3baf6a018914da4f1c2ae9023e23fb41e131b68b3e3f9ca41ecef61
+  md5: a36aa6e0119331d3280f4bba043314c7
+  depends:
+  - python >=3.9
+  - snowballstemmer >=2.2.0
+  - tomli >=1.2.3
+  license: MIT
+  license_family: MIT
+  size: 40236
+  timestamp: 1733261742916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydot-4.0.1-py311h38be061_0.conda
+  sha256: 7483218e6ff1f7b0bbd3b7fb9c71c1b8fda70722ae5e10747db1bee04fd4460d
+  md5: 65cb377afd9f3f8b3077008677926315
+  depends:
+  - graphviz >=2.38.0
+  - pyparsing >=3.0.9
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 86816
+  timestamp: 1750503649380
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pydot-4.0.1-py311hec3470c_0.conda
+  sha256: 0a1bdca9856389fc076197fe3999f6d4f3f40f3fe7c5d1a1273cae73cd78efc8
+  md5: fed0ef8a00d124dc9ce109c7c66b02ad
+  depends:
+  - graphviz >=2.38.0
+  - pyparsing >=3.0.9
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 86935
+  timestamp: 1750503778267
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-3.4.0-pyhd8ed1ab_0.conda
+  sha256: 4b6fb3f7697b4e591c06149671699777c71ca215e9ec16d5bd0767425e630d65
+  md5: dba204e749e06890aeb3756ef2b1bf35
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 59592
+  timestamp: 1750492011671
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 889287
+  timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
+  sha256: b92afb79b52fcf395fd220b29e0dd3297610f2059afac45298d44e00fcbf23b6
+  md5: 513d3c262ee49b54a8fec85c5bc99764
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 95988
+  timestamp: 1743089832359
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311he22028a_1.conda
+  sha256: c2b568492db18dfaf9d920498bc338c657a2a5db65ed82287f73846ecea0fe66
+  md5: bfd19c4ed7170fe34df119f5b225a5bf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt5-sip 12.17.0 py311hfdbb021_1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 5242946
+  timestamp: 1749226326779
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py311h70a6756_1.conda
+  sha256: 9a85ce43d1a34e6ae79f03d14a93de16254191fcbc8bb6041f8c6feadb528941
+  md5: 34707ca04fc77d1b7930dfd51b6dbd8b
+  depends:
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt5-sip 12.17.0 py311h89d996e_1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - qt-main >=5.15.15,<5.16.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 6273625
+  timestamp: 1749226653991
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-builder-1.15.4-pyhd8ed1ab_1.conda
+  sha256: 7000bf38da6e5235b4501567a947b98c16bd3a64ed24a2b3810ee7952d93becf
+  md5: e7e42825f9277818ad114fea56385dae
+  depends:
+  - packaging
+  - python >=3.9
+  - sip
+  - toml
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 2965472
+  timestamp: 1742182116448
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py311hfdbb021_1.conda
+  sha256: f2fbe31a7bd423c2d473516de5a2f648f6cc598350d233d2459390a6da8b15bc
+  md5: e5dfc88ced7eae4918db0dd17c28633f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - sip
+  - toml
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 84215
+  timestamp: 1749224312844
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py311h89d996e_1.conda
+  sha256: af218fa6c4816e7591b50db5c58191ebd961c36821cdb84b0f75e962bd513089
+  md5: 823252563080739289e81ac6e7bbac4b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - sip
+  - toml
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 89209
+  timestamp: 1749224391517
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+  sha256: 93e267e4ec35353e81df707938a6527d5eb55c97bf54c3b87229b69523afb59d
+  md5: a49c2283f24696a7b30367b7346a0144
+  depends:
+  - colorama >=0.4
+  - exceptiongroup >=1
+  - iniconfig >=1
+  - packaging >=20
+  - pluggy >=1.5,<2
+  - pygments >=2.7.2
+  - python >=3.9
+  - tomli >=1
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  size: 276562
+  timestamp: 1750239526127
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+  sha256: 3a9fc07be76bc67aef355b78816b5117bfe686e7d8c6f28b45a1f89afe104761
+  md5: ce978e1b9ed8b8d49164e90a5cdc94cd
+  depends:
+  - coverage >=7.5
+  - pytest >=4.6
+  - python >=3.9
+  - toml
+  license: MIT
+  license_family: MIT
+  size: 28216
+  timestamp: 1749778064293
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-repeat-0.9.4-pyhd8ed1ab_0.conda
+  sha256: cea7b0555c22a734d732f98a3b256646f3d82d926a35fa2bfd16f11395abd83b
+  md5: 9e8871313f26d8b6f0232522b3bc47a5
+  depends:
+  - pytest >=5
+  - python >=3.9
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 10537
+  timestamp: 1744061283541
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-15.1-pyhd8ed1ab_0.conda
+  sha256: 661e2918446f291d0c28226feb4bd477753ddcf70f78f5ca15f24e5282f5344e
+  md5: 82f0d25c48b2cf1551b509d1c1c248e6
+  depends:
+  - packaging >=17.1
+  - pytest >=7.4,!=8.2.2
+  - python >=3.9
+  license: MPL-2.0
+  license_family: OTHER
+  size: 18890
+  timestamp: 1746703832352
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
+  sha256: 9979a7d4621049388892489267139f1aa629b10c26601ba5dce96afc2b1551d4
+  md5: 8c399445b6dc73eab839659e6c7b5ad1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30629559
+  timestamp: 1749050021812
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.13-h1683364_0_cpython.conda
+  sha256: b44a026ac1fb82f81ec59d4da49db25add375202f7f395b6c2cb1384ad6a33d6
+  md5: 4efe51e746f7c0abc30338e6b3d13323
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15306062
+  timestamp: 1749048115706
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
+  depends:
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
+  build_number: 7
+  sha256: 705d06b15c497b585d235e7e87f6c893ffe5fbfdb3326e376e56c842879e0a09
+  md5: 6320dac78b3b215ceac35858b2cfdb70
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6996
+  timestamp: 1745258878641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
+  sha256: d107ad62ed5c62764fba9400f2c423d89adf917d687c7f2e56c3bfed605fb5b3
+  md5: 014417753f948da1f70d132b2de573be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 213136
+  timestamp: 1737454846598
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py311h58d527c_2.conda
+  sha256: b7eb3696fae7e3ae66d523f422fc4757b1842b23f022ad5d0c94209f75c258b2
+  md5: 01b93dc85ced3be09926e04498cbd260
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 206194
+  timestamp: 1737454848998
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+  sha256: 49f777bdf3c5e030a8c7b24c58cdfe9486b51d6ae0001841079a3228bdf9fb51
+  md5: bb138086d938e2b64f5f364945793ebf
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  size: 554571
+  timestamp: 1720813941183
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hea1682b_4.conda
+  sha256: 723a2afd0a1d15baf20117ba6fa5c03ecb161557c607ef542eb017ff422198f7
+  md5: c054d7f22cc719e12c72d454b2328d6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gst-plugins-base >=1.24.11,<1.25.0a0
+  - gstreamer >=1.24.11,<1.25.0a0
+  - harfbuzz >=11.0.1
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.4,<20.2.0a0
+  - libclang13 >=20.1.4
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.4,<20.2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libpq >=17.5,<18.0a0
+  - libsqlite >=3.49.2,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.9.2,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.111,<4.0a0
+  - openssl >=3.5.0,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 52525654
+  timestamp: 1747033292625
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-hf34aa0b_4.conda
+  sha256: 22646cfab7c5c72f2dfb1b5867550713bf1362171bc5d0c7c0abbbf45026c086
+  md5: d30d4069d51ada57f4d4d20ce4aed465
+  depends:
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gst-plugins-base >=1.24.11,<1.25.0a0
+  - gstreamer >=1.24.11,<1.25.0a0
+  - harfbuzz >=11.0.1
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.4,<20.2.0a0
+  - libclang13 >=20.1.4
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.1,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.4,<20.2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libpq >=17.4,<18.0a0
+  - libsqlite >=3.49.2,<4.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.9.2,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.111,<4.0a0
+  - openssl >=3.5.0,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 51814164
+  timestamp: 1746739351687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.8.3-h75f3359_4.conda
+  sha256: e3136c8959fb4323525ffa3dc1178bc4023dae11e76b79a24a253c8a1d74eb9d
+  md5: a112bbcd817da41b3db983a7f2d78fd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.16.2,<2.0a0
+  - double-conversion >=3.3.1,<3.4.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - harfbuzz >=11.0.1
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libclang13 >=20.1.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.2,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libpq >=17.5,<18.0a0
+  - libsqlite >=3.50.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.10.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.3.0,<9.4.0a0
+  - openssl >=3.5.0,<4.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-cursor >=0.1.5,<0.2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 6.8.3
+  license: LGPL-3.0-only
+  size: 51530505
+  timestamp: 1750921297282
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt6-main-6.8.3-he176c03_4.conda
+  sha256: bf0485bf2b9e85b2f5c7035e9ecb0754926dceab13e389bdb2c46b4984491e11
+  md5: a1dc52c4c9f976c4936b306242586c10
+  depends:
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - dbus >=1.16.2,<2.0a0
+  - double-conversion >=3.3.1,<3.4.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - harfbuzz >=11.0.1
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libclang13 >=20.1.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglib >=2.84.2,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libpq >=17.5,<18.0a0
+  - libsqlite >=3.50.1,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.10.0,<2.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-libs >=9.3.0,<9.4.0a0
+  - openssl >=3.5.0,<4.0a0
+  - pcre2 >=10.45,<10.46.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-cursor >=0.1.5,<0.2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - qt 6.8.3
+  license: LGPL-3.0-only
+  size: 54270004
+  timestamp: 1750920790705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8382b9d_2.conda
+  sha256: 54bed3a3041befaa9f5acde4a37b1a02f44705b7796689574bcf9d7beaad2959
+  md5: c0f08fc2737967edde1a272d4bf41ed9
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 291806
+  timestamp: 1740380591358
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.3-hd590300_2.conda
+  sha256: 475f68cac8981ff2b10c56e53c2f376fc3c805fbc7ec30d22f870cd88f1479ba
+  md5: 4cabe3858a856bff08d9a0992e413084
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 184509
+  timestamp: 1693427593121
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.3-h31becfc_2.conda
+  sha256: 60208d76e55e80d2bbe5e166d31849bffd2b09684e46a59e8611e3b9ec3a47c5
+  md5: b24e1c4aa0cca0aacc7652724590fa29
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 198849
+  timestamp: 1693427573478
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-msgs-1.2.1-np126py311h2c3b307_7.conda
+  sha256: 15c850bd145b1c00c9824050421694b5ea1fc92a9fe38495348de0af2c385543
+  md5: 03d5d5e407d734d006eb7b19f2b4ebed
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-unique-identifier-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 113255
+  timestamp: 1736209174927
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-msgs-1.2.1-np126py311h65a17ee_5.conda
+  sha256: e594d9f4dea6fbaa0fdf87cc416d2fe06e04864950db4865995cc2e0e19c8c46
+  md5: ce38d28a84707e427d5d97a9c5254f62
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-unique-identifier-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 117112
+  timestamp: 1736211408135
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-cpp-0.20.5-np126py311h2c3b307_7.conda
+  sha256: a37f3e26d883717f3a8b450602a9a094dafee84f15a8909e283df5aaf6ab7754
+  md5: 54c935e2c8492cd5c6c2110a5347cf5f
+  depends:
+  - python
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 129863
+  timestamp: 1736210613035
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-cpp-0.20.5-np126py311h65a17ee_5.conda
+  sha256: a5e46c86976b6da07936e6d85b279aee9ac2d4208aaec6842807dae33031f3ff
+  md5: 5c77cc6eb880a2c0b74f6d4459a7598f
+  depends:
+  - python
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 133846
+  timestamp: 1736214639223
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-interfaces-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 5bb70eaaf65a622d3a0d08730306ab5e2ea477314398fbd8f2f265f2f42674ac
+  md5: c0c29fb868ef7f242749080a368a1ebf
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 125800
+  timestamp: 1736209387131
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-interfaces-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 7496d14d250aa91bbe8778172f6bc637ba7816882bfbb1336d62376ee239f20d
+  md5: ee8914aed135f7d2048eebb2c573dfe9
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 128763
+  timestamp: 1736211867098
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-action-tutorials-py-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 7edbb5c1ccfb7f6c020399e2ba0e43496b5ff7f9e2a83cc7d45bd46fa9bd21ee
+  md5: d6cc4f69ab414a7cc57e3f5bf4c03774
+  depends:
+  - python
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29919
+  timestamp: 1736210410985
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-action-tutorials-py-0.20.5-np126py311h65a17ee_5.conda
+  sha256: c5f2bb6f1b3b135713f8def20e8ba241af36230d33ee0a3be0fcc02e9a91d50f
+  md5: 302a68582918bb6fecd17476980bd505
+  depends:
+  - python
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 29865
+  timestamp: 1736214168530
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-actionlib-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: ba7c4da796226718cfb9368529f590fa1b2c9d53710901a7fc748d648d599dad
+  md5: b329fa326a4faaec014668e24e7c0326
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 99149
+  timestamp: 1736209423459
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-actionlib-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: ec748af025b96ecffd90880db49177f4dcc69bca9df7b84c2ac846264602dd0f
+  md5: c88381d0b8c8d14f01e62b805fe5896e
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 101975
+  timestamp: 1736211890202
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-clang-format-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 8c78e260b86cd3c38101a8d177c48ef53edd1d355c6b7b6785671a3fa1f9be76
+  md5: 5a924d0082948a4e3bb40de9e01848dc
+  depends:
+  - clang-format
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 29767
+  timestamp: 1736207112444
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-clang-format-0.12.11-np126py311h65a17ee_5.conda
+  sha256: fc9a79ddd8efd5c55e91aa93612bfc0f5fabdde69dfa35683db57ef37261e5c8
+  md5: b9445a23ba5bb0d85737f9748b66e73a
+  depends:
+  - clang-format
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29729
+  timestamp: 1736207331398
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 23e4a88ccbdc761ffbf89bd51135769c84006b1849b4e58f041ecc6878f5ae48
+  md5: ee0a75fcf398d8bc287aa01b87076538
+  depends:
+  - cmake
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-definitions
+  - ros-humble-ament-cmake-export-dependencies
+  - ros-humble-ament-cmake-export-include-directories
+  - ros-humble-ament-cmake-export-interfaces
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ament-cmake-export-link-flags
+  - ros-humble-ament-cmake-export-targets
+  - ros-humble-ament-cmake-gen-version-h
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ament-cmake-python
+  - ros-humble-ament-cmake-target-dependencies
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cmake-version
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21698
+  timestamp: 1736207108010
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 21feac36a6a246469b583707dea65dc952feda9a3eb1c699e44bb9bd2926a387
+  md5: 3dd84e0f823fb37cbc4cb5baa260386a
+  depends:
+  - cmake
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-definitions
+  - ros-humble-ament-cmake-export-dependencies
+  - ros-humble-ament-cmake-export-include-directories
+  - ros-humble-ament-cmake-export-interfaces
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ament-cmake-export-link-flags
+  - ros-humble-ament-cmake-export-targets
+  - ros-humble-ament-cmake-gen-version-h
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ament-cmake-python
+  - ros-humble-ament-cmake-target-dependencies
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cmake-version
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21616
+  timestamp: 1736207317454
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-auto-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 3cf30c5f54b43e8396dbc4fc110d7b356c2349b990e2e88090e3523960441571
+  md5: 7936416b355dffde1ee1da4e2e093ebd
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25389
+  timestamp: 1736207181026
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-auto-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 64cf55b3d248e4bc02db2c55529397704903cf35b4fbd52d0b222deeaa749f98
+  md5: bc5173f1d361e2126094d92cb540d863
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 25374
+  timestamp: 1736207511052
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-clang-format-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 8a7bcf46172d89ca104fa01485591e724158a2591d070cdc926d23e8902fe0ea
+  md5: cb7fdc535448c773ebc20f7de8261a34
+  depends:
+  - python
+  - ros-humble-ament-clang-format
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22293
+  timestamp: 1736207501468
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-clang-format-0.12.11-np126py311h65a17ee_5.conda
+  sha256: e06f82b217ac1070aba331b67decb2627e67ea5f4c5aa471c301d8c58b387674
+  md5: 106372283a7c2eb6b03ccd90f954451d
+  depends:
+  - python
+  - ros-humble-ament-clang-format
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22339
+  timestamp: 1736207931475
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 773e5e132aa070efc953723dd28ebb94d3177625d494a5e1803bcea30cd7cd2d
+  md5: c9fa5f251605ed495fc3639d198b4c50
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-copyright
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21158
+  timestamp: 1736207413133
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-copyright-0.12.11-np126py311h65a17ee_5.conda
+  sha256: c57545d3639e1fbe91ffb3466e48061f0309f22a0f1084e63b37e74bb6808c27
+  md5: bd44a4c1c36455b538d1eaba8b35872a
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-copyright
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21095
+  timestamp: 1736207679599
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-core-1.3.11-np126py311h2c3b307_7.conda
+  sha256: c03405e62fd6d62191b0d246dca97712a3f104bd3efaac18d92ef8cd13e02823
+  md5: b481c03fa5af51cb5982fdec4618befe
+  depends:
+  - catkin_pkg
+  - cmake
+  - python
+  - ros-humble-ament-package
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 43586
+  timestamp: 1736205314893
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-core-1.3.11-np126py311h65a17ee_5.conda
+  sha256: d3cd66362a41ecbcd1f43de4b6f218d5a919e9550087ff52fa634ad57724788e
+  md5: e2b1a4d1b4fe51438502faa933f5de1e
+  depends:
+  - catkin_pkg
+  - cmake
+  - python
+  - ros-humble-ament-package
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 43562
+  timestamp: 1736205609174
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h2c3b307_7.conda
+  sha256: b5244bb6e8d33983fb968327e258ec2718c151972734768039000d8a9ecfb852
+  md5: 2edd28e20d62c13ace301f89c0abac21
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cppcheck
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22784
+  timestamp: 1736207478968
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-cppcheck-0.12.11-np126py311h65a17ee_5.conda
+  sha256: be1d35acc461505795f4ce1be2d34a8c14843f7d5dfe3e9dac8745c31e386ffc
+  md5: 4f4f291ae9a3d576d24cab2d84c29516
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cppcheck
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22735
+  timestamp: 1736207888399
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 796bc98dc66ffac37b84da64d1943a1b50306e88e24e939947ed4c1df6d4991e
+  md5: f204d58f0c5d0447af2ace2d653c7016
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cpplint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21649
+  timestamp: 1736207507771
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-cpplint-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 0cc3db1d2c7fef7a224753a473130f3b28b23ccbdc024cda1c63d61da5c3112c
+  md5: 2b04f73c767aff54a9c69297c0c67a75
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-cpplint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21575
+  timestamp: 1736207932982
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 3312be0a0090c5dea6a4a6539b2445b0f6af8c859b081742c27852ebb3db504c
+  md5: 1616226e84d7d96b67b562a42998ccab
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20548
+  timestamp: 1736205374472
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-definitions-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 6bf69379d3525d809ef368399b1b7eb6bf7f0aff5da57a93820859ac3a994c93
+  md5: a5688acb8436c39fcbdc96b87ec99725
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20484
+  timestamp: 1736205796809
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h2c3b307_7.conda
+  sha256: ca8e343bb56568ac6103a2343e75c88ee026730fb67d1126cf7b0ffae1518ae1
+  md5: a47fce87cc31132d8fd1c07aadd58485
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21490
+  timestamp: 1736206833507
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-dependencies-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 1969571ff98f0bb2576901d49ca7f2bae24cb5e5cfacf6941959bea4c2200f8d
+  md5: e78aa70e3aee742de743531f6af3c430
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21431
+  timestamp: 1736206701772
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h2c3b307_7.conda
+  sha256: fa21a9f2db81a30bdd1adc00607bf2d247a2fc4dca8e6798dd92f55bbeaa14b7
+  md5: 6b5ce82a7fe33f2e91ae4ac1a94ccb3f
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20962
+  timestamp: 1736205370838
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-include-directories-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 02409c865b6f1d3f60a9680af8b5eae04a086be57dd49788f5a80fa090e60944
+  md5: 21c84c280d4db3e7e403b6418ddb14ea
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20907
+  timestamp: 1736205788584
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 044d715c407b25e9b84add16fa6d4db8137c4fee7fa10b3e355dc790235c8567
+  md5: 0c628430cf7c32fcc1b4805e72735b7e
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21158
+  timestamp: 1736206863821
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-interfaces-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 5ce10864d22c0d011dd8ae28f17417d1737a95cf08d8f73eb0337102c6db8ca9
+  md5: 497d8bd23ba8de345d931868639e4294
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21113
+  timestamp: 1736206756783
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 42ef8accfa2f2a8dff64a255d200733d32799bd2939691c7ad388c31424f004a
+  md5: d6e39dc492c7dfe395fc13f147c7aa3f
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22481
+  timestamp: 1736205352627
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-libraries-1.3.11-np126py311h65a17ee_5.conda
+  sha256: bce71951ffd79683e3cac94e085086e2f7b4579cfbac96e9f6a0aa15bb0e4e3a
+  md5: 464e4b6d701c9c88601ad3e471b8b9b2
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22462
+  timestamp: 1736205754625
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h2c3b307_7.conda
+  sha256: b847d395b22456e462fab27b140555f0582b35d7f53427d95590ad2a742163b2
+  md5: c0b178f47eb707335321239a6ab2f7c3
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20548
+  timestamp: 1736205366906
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-link-flags-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 629482fb0be488b0ef181c83685c00005303d68ca080c2b6e4f3467c4c0ce984
+  md5: 4733c07bbbb18a068eba726d811467e4
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20435
+  timestamp: 1736205780605
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h2c3b307_7.conda
+  sha256: d103b760ab84bc7516320ac07eae351922c8315ce87b7dc79411b2e5ecf13db0
+  md5: 0ea169ff34b677b672bfbda5626d4041
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21323
+  timestamp: 1736206859567
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-export-targets-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 2b017e48d6e2256666c171c3a9df82d21311a989ca29cf61c00f9dbebb2e7856
+  md5: ae5de4fb523fcb89759468c535af3abc
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-export-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21257
+  timestamp: 1736206748530
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 1d988b0373d481884d1ea419c83c96369669fe490e5bf2ca3aab3ea109c81a1d
+  md5: 73e58a5a02356d71e00bbe25c2ae8ee5
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-flake8
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21902
+  timestamp: 1736207503447
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-flake8-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 8c253be43710be1552c4c8ece674eaccefa67e5b18ca17d8901c00b69ad8c951
+  md5: 68dca674a82a35ff8642119678ecba59
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-flake8
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21836
+  timestamp: 1736207924624
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 50649cb811b244995a57d5d938a7eeff990f220be67b5c06d31787856bac1304
+  md5: 75cedd56c7e6b0c86dbcf8a076d4504a
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 23281
+  timestamp: 1736206998497
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gen-version-h-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 8c34dfb8a732f0a8172834577d7b944a57ec64ceb95dd55e137e33585f0ae895
+  md5: 344a3e393bc93b407da61986199b1998
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 23237
+  timestamp: 1736207115092
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h2c3b307_7.conda
+  sha256: e34e880a128d657392cb1fc4699704902745d7f22821e8a2c1249f8d730b09bf
+  md5: 363bb5cf965f797f9a1e9784e898daf1
+  depends:
+  - gmock
+  - python
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-test
+  - ros-humble-gmock-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22859
+  timestamp: 1736207005970
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gmock-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 381023491a04e7523adfa3518d8f59dde1be8da265414d008103d03944d99fba
+  md5: 4c3d8a4f222841e8299e58ea43730642
+  depends:
+  - gmock
+  - python
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-test
+  - ros-humble-gmock-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22818
+  timestamp: 1736207129105
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h2c3b307_7.conda
+  sha256: b11d04f83877f48fb5966b96d59a1c80ce94c3134c786621d01ffa525df7e7f8
+  md5: 8d3230320ed54ac6153902c2203436cb
+  depends:
+  - gtest
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-gtest-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - gtest >=1.15.2,<1.15.3.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 23111
+  timestamp: 1736206933818
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-gtest-1.3.11-np126py311h65a17ee_5.conda
+  sha256: faeaeb4422fc6ba21f9d6f7cdfe123664e6c1acd2bac162e6060ed175cb41322
+  md5: c14b41246a88da593a3cba9fcb26ec61
+  depends:
+  - gtest
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-gtest-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - gtest >=1.15.2,<1.15.3.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 23052
+  timestamp: 1736206941586
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 08d4ba482a6f697ce0299fb030f9b27a7ea00d0f5326e8ecb99d6e0b8732798e
+  md5: 0e7a11d653aef8b622a648b7480196ba
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20393
+  timestamp: 1736205377055
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-include-directories-1.3.11-np126py311h65a17ee_5.conda
+  sha256: bed9bec70c87a977d7141ac2af6a1d1a3aa5f29e688e597aba298d1cabbbce4b
+  md5: 17f1dc8d041947709ac5e3440089dbe2
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20377
+  timestamp: 1736205805018
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 20d33b463dcaa986f7057ede995c96b84eda6c37c83ad8aa0b6a6bec6fec4b92
+  md5: 70d50c3633cc3fba38b228779d86bef6
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20103
+  timestamp: 1736205373435
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-libraries-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 85ca5a32018c63cfd4fb6cebfe826bbf1a2aebc2374eced5b9866b4089f47e87
+  md5: 8152de6b1992178357de07ee00ff5a3b
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20083
+  timestamp: 1736205797170
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 90c83b3de00c6d88591a0f286df3b4ee181c7c47afe4be3bedea8f6fd9816bf5
+  md5: 34e3f94ddf7afa9463ba07955eb5c34f
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-lint-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20823
+  timestamp: 1736207167608
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-lint-cmake-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 992487140a10a6d117164a950e56607d8ac68b2b68ee7306facedf0a6c15d3d9
+  md5: 83edff53e75045ace8906626e39f2161
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-lint-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20777
+  timestamp: 1736207472216
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 02c0695afd3798edd9f873246b3c3898be82085ae59ed24bfc38bfdd315f7eb2
+  md5: 71311da5e5ed80a4e15fc46285e43afc
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-pep257
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21607
+  timestamp: 1736207499388
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-pep257-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 6bc47af9bed6942d045a877b7390967bfa45d75850711d0f42216d5ea3ea0e95
+  md5: 10904cc85506cd561a93fe913160b3d8
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-pep257
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21504
+  timestamp: 1736207914708
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 2d7263c5e6576089a7f9ea700976956134a38b6ecc3b87bb9a2694dbdd844273
+  md5: 36b452cc0f53b2c93f86880e5bd7bcc2
+  depends:
+  - pytest
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 23128
+  timestamp: 1736206948145
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-pytest-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 76d09bd4d7a12975b2d511888723488602d9389c749ee33890ee9d6f428db3c4
+  md5: cc46bd96e3563b2eb9bf6476baea4267
+  depends:
+  - pytest
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 23095
+  timestamp: 1736206972599
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-python-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 47ce511bdee4659c51169b28c3d2fd0146b3700a3f22d59841463e3a1d75cc80
+  md5: 2012aca135f7d3b82ea8453e357fac8d
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 23040
+  timestamp: 1736205363819
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-python-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 9d492c58ca086b111d8f141284f386077dd59cfebfa94579ea49b174c907dd24
+  md5: eaf3e47248d75ab1c08314c22137e43f
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22987
+  timestamp: 1736205777922
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-ros-0.10.0-np126py311h2c3b307_7.conda
+  sha256: 005b202f7fc9210489ebdf03a163cbad34a4c987aa68e453d220ea398af8c0ad
+  md5: 3def493e443c1e454bfb6a6c4d474c3e
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-pytest
+  - ros-humble-domain-coordinator
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29102
+  timestamp: 1736208189632
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-ros-0.10.0-np126py311h65a17ee_5.conda
+  sha256: 69478276f3b45446c9da254334a0eccfc28e8262f9c523d7c2b31445c12af7a7
+  md5: a29a92af842f44f105f82fd090538def
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-pytest
+  - ros-humble-domain-coordinator
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29115
+  timestamp: 1736208552102
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h2c3b307_7.conda
+  sha256: d62c1f14d169a8565ed9f201b9f73598041e2f8382e6e2c890eec3e866604eaf
+  md5: caa0adf1df6773fc4bc23bd23c9451f7
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-include-directories
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22108
+  timestamp: 1736206855233
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-target-dependencies-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 79d3f76d57b9038e3f0fe9731938505e661d84610a8720dd798707d759639310
+  md5: e20e0bbfb1cbd1ad891c0351400dcd2d
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-include-directories
+  - ros-humble-ament-cmake-libraries
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22078
+  timestamp: 1736206740192
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-test-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 2f978c4098b0c4731ae61bda6b298ddebcad6ca64b19a743aec7867a2e6d9f2e
+  md5: 80a632762483d5a26fa4494f2c152d6f
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 34688
+  timestamp: 1736206848007
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-test-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 7b4d49892866bb0eb5ab3dca530d3b3b8e7c8e2c6fde606a14008febea48f9b1
+  md5: 8110e29cae885c558ab07d79b538256f
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 34712
+  timestamp: 1736206725698
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h2c3b307_7.conda
+  sha256: adfd92d2873ef269a4d426684ede008d2222969fb5da2410a9e8b4b68e671fa8
+  md5: 43b73f7f089d76b2e89d7cae274d3b43
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-uncrustify
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21934
+  timestamp: 1736207494072
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-uncrustify-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 20ce4622eb9aceaf05d4de2aeff52a822e8cb9dc832d5a39dc6a7e84724fa7d4
+  md5: 025143615bf8c37d8e55d552776c511f
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-uncrustify
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21922
+  timestamp: 1736207906244
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-version-1.3.11-np126py311h2c3b307_7.conda
+  sha256: 5b700c9fd1474e5a8b21f8bc807b02258ce3b750d56278be0b2e03148bd3c9a7
+  md5: fbd1026fc17d5d6cb9d1cbdf3d4794dd
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20260
+  timestamp: 1736205363204
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-version-1.3.11-np126py311h65a17ee_5.conda
+  sha256: 6c8fe261fd48f24ff71220985b0a96893a1e677925d0995660431afbde9cee47
+  md5: 59b2d3c63a83bd039295f5f800eef747
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20220
+  timestamp: 1736205772701
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h2c3b307_7.conda
+  sha256: e19b2df307f9e39a2f60860522c36d0c26725515949e282e35129efe602f99d1
+  md5: 0c1a923bbaf3322ebd4fd9469d0d71f6
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-xmllint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21463
+  timestamp: 1736207482611
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cmake-xmllint-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 6186d2d5eb72aee0029129c0644b7b8f1d6b4be0592a3d90a43c1cfdf83c6dac
+  md5: 03c4b87d0983d66bfdb7ab6600d3ab04
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-ament-xmllint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21481
+  timestamp: 1736207886310
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-copyright-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 388dd42e53c4548a1777c24ec1441d83a628f61860cfb267e85e693ecac3a63b
+  md5: c672f0ddc5c600c2dd35026fedfa5efb
+  depends:
+  - importlib-metadata
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 64477
+  timestamp: 1736206986194
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-copyright-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 54706a743183ad8b8ff2822c6bf57ea1bdeb4e63424b1541f4db3c83f57596e3
+  md5: 3d4e56a2ddb9782094bff0354a17e538
+  depends:
+  - importlib-metadata
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 64464
+  timestamp: 1736207093416
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cppcheck-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 9de3d5aa2a1095b1c78c3113b672a13d68143baf22f0f36b90255ff120058383
+  md5: c4140ce5debf18f8bfd39ff869511b0e
+  depends:
+  - cppcheck
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27000
+  timestamp: 1736205365978
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cppcheck-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 67c7655b84f38a6524bee6628533fcd029022cfd85ab67d60477e96d51470cdc
+  md5: 18e6fa2e5ffcacedcb4cb07e3dead457
+  depends:
+  - cppcheck
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 26985
+  timestamp: 1736205775181
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-cpplint-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 9e79cafd49aabad82ee69b463d30500d78e2fb1228075258a1816d79212663ce
+  md5: f902ee8a89f72f4f7954c9e24af3e2fe
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 175232
+  timestamp: 1736207120962
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-cpplint-0.12.11-np126py311h65a17ee_5.conda
+  sha256: aa58aba5ab0e772d0332bf006c6189bf23e0806562661a23b9df3cf16e41f9b2
+  md5: 5d5f7214e369c4ca38cc1a63a60f872f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 175196
+  timestamp: 1736207342186
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-flake8-0.12.11-np126py311h2c3b307_7.conda
+  sha256: e3e7e01b652867ef71b6e4b9eb0a7377d591408826ac309d8aae248280bd7357
+  md5: 0ec5ee13cb37dc5c46a45d243c76f48b
+  depends:
+  - flake8
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 28176
+  timestamp: 1736206834454
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-flake8-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 35e6818befee636d59e9a179e0fa7921fb7e7371b18aafffe64be831ce03de63
+  md5: 1b9d5d00c529592fb255afc7dccd1e33
+  depends:
+  - flake8
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 28139
+  timestamp: 1736206704509
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-cpp-1.4.0-np126py311h2c3b307_7.conda
+  sha256: 4dd3a439868403c3ff9ebe22bf786765d802a1a9f2ace349259d11eb26187512
+  md5: 217fa69e0b2dcc2f6fbd1f91a45bc516
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 44158
+  timestamp: 1736208165886
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-index-cpp-1.4.0-np126py311h65a17ee_5.conda
+  sha256: 2a66f208d76a8476b74c94122a560c376f547de46e3615b193dd294b4b4677b0
+  md5: c00012ba1a08970e0b28f1341252c14f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 43664
+  timestamp: 1736208503467
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-index-python-1.4.0-np126py311h2c3b307_7.conda
+  sha256: ab29d83fb3bbd8207557a246e27209e27d84392c3119ed2a5ef2d9a0137bb858
+  md5: 86402019c344731609103b4808091600
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27854
+  timestamp: 1736207126404
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-index-python-1.4.0-np126py311h65a17ee_5.conda
+  sha256: 1044ebffa86f3917c7ec426d03ead3e11f619858fe7c1a381c8a206134f78369
+  md5: 45963b55d85c21397e23b58214d64ebb
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27833
+  timestamp: 1736207354611
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 5c4d125b5d67659b44166d0bef409b0f2e1e5ef2c6e666ba06348f369e296790
+  md5: 4f2d9d6a9c610932d966f034400ba36f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 16167
+  timestamp: 1736205352483
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 995bcc31e11a01839b9ac292346f6e1abb966a340896693063d2097566cf4ec9
+  md5: 8c55eb0fde965aa7bfe69dca75165a17
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 16131
+  timestamp: 1736205757023
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-auto-0.12.11-np126py311h2c3b307_7.conda
+  sha256: ea4fc847e79f5de3beccf45f74460e2d7150c3992258886c8cdaf2859f0482aa
+  md5: fc1c5838b478028ea842b138d89ffa19
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20486
+  timestamp: 1736206940032
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-auto-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 883a689863c4a2b1996efd13920541ff5a086e672ed579fc33b36ca025f6a3ed
+  md5: 9e9ca58f739f51ad2210979e5ae8627c
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-test
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20468
+  timestamp: 1736206954905
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-cmake-0.12.11-np126py311h2c3b307_7.conda
+  sha256: b89fad016ba75944dbd128dbb2b244d5528eccfaba12bd7db67b531ff6876fc8
+  md5: a6ab244960992fa7c8cf91a4d7ae1237
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 39423
+  timestamp: 1736207095186
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-cmake-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 59ce1f4aa2f4ba46cb69d4801d11da9b8cb9f6fbb1ed7c90792a9736fc16c281
+  md5: 2d006f27d6bc10c15f65333ff954ff67
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 39363
+  timestamp: 1736207294637
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-lint-common-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 5549272b5213df130c58b0d966afa163733ff29db343eb1924e866bb1e03d235
+  md5: 76782fb32c11de3eed6063c50e4071e1
+  depends:
+  - python
+  - ros-humble-ament-cmake-copyright
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-cppcheck
+  - ros-humble-ament-cmake-cpplint
+  - ros-humble-ament-cmake-flake8
+  - ros-humble-ament-cmake-lint-cmake
+  - ros-humble-ament-cmake-pep257
+  - ros-humble-ament-cmake-uncrustify
+  - ros-humble-ament-cmake-xmllint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20770
+  timestamp: 1736207545999
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-lint-common-0.12.11-np126py311h65a17ee_5.conda
+  sha256: df94b11929cfd3617949411646b950778f528da9f4399fdae98f7fee51752267
+  md5: 6d8cb67672748ad60891df1cedebf52d
+  depends:
+  - python
+  - ros-humble-ament-cmake-copyright
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-cmake-cppcheck
+  - ros-humble-ament-cmake-cpplint
+  - ros-humble-ament-cmake-flake8
+  - ros-humble-ament-cmake-lint-cmake
+  - ros-humble-ament-cmake-pep257
+  - ros-humble-ament-cmake-uncrustify
+  - ros-humble-ament-cmake-xmllint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20703
+  timestamp: 1736208046180
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-package-0.14.0-np126py311h2c3b307_7.conda
+  sha256: c75cc1ae8ef017f0752b65f6d5325b706e640983d9ac96fdea35bac7ca009a48
+  md5: 158a13122d7eb30aa58975d7ba565663
+  depends:
+  - importlib-metadata
+  - importlib_resources
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - setuptools
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 47117
+  timestamp: 1736205283929
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-package-0.14.0-np126py311h65a17ee_5.conda
+  sha256: 20eadb4844fa2915b022980feb70329c0f87263baa0fbec62e0e9392f3afe846
+  md5: d4d01449014f4090512d55572f81581d
+  depends:
+  - importlib-metadata
+  - importlib_resources
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - setuptools
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 47113
+  timestamp: 1736205479167
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-pep257-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 7601c4cf2fcb3a115e2ff157ab2eac9dacd42cea40d875208ba5f8aba51baa0d
+  md5: d11ce05f0c2491e4828bc2ae043b19ac
+  depends:
+  - pydocstyle
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25767
+  timestamp: 1736206920920
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-pep257-0.12.11-np126py311h65a17ee_5.conda
+  sha256: be091fe6877cd4d5a246f5fde415fd5c82fea3478e16cdae085c1ec08971f293
+  md5: b72d4aa19fede6f8a1e9611388a47d65
+  depends:
+  - pydocstyle
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 25758
+  timestamp: 1736206920397
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-uncrustify-0.12.11-np126py311h2c3b307_7.conda
+  sha256: 9bf2656e1967057a529e5b298cf3159a025e06ba24548059943259dcc8d7b30c
+  md5: ee37deb5784e7c194c371c82e30d6fb2
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-uncrustify-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 48745
+  timestamp: 1736207425020
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-uncrustify-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 0ecdd8eaaa1125c5c2043a08a548183609285113dd6f93123e30e7950bcc465c
+  md5: 18994f2c4db8c1194dd1875472bbcfb9
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-uncrustify-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 48679
+  timestamp: 1736207698407
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ament-xmllint-0.12.11-np126py311h2c3b307_7.conda
+  sha256: f0e165150a0b35cc8a63318763d84810030885615da30ae2bb89d3bf7497c313
+  md5: 4b16b51995b0658352b14ffeb2c90add
+  depends:
+  - libxml2
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27150
+  timestamp: 1736207115722
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ament-xmllint-0.12.11-np126py311h65a17ee_5.conda
+  sha256: 80ef04aef38aa6be1c645c6705cd7810bc94a01230651616a51d8c007449dc3a
+  md5: 73bad65f55d3b26e5f18bac2a13734e7
+  depends:
+  - libxml2
+  - python
+  - ros-humble-ament-lint
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 27076
+  timestamp: 1736207330040
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-angles-1.15.0-np126py311h2c3b307_7.conda
+  sha256: 54424e7f004f8e12afcda941f32f716cf0597c56bb4eb0ab197aa28c860c7ed0
+  md5: cfb2dabad689326e0fcaa28939c8224f
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 31152
+  timestamp: 1736207359497
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-angles-1.15.0-np126py311h65a17ee_5.conda
+  sha256: 432376fe455537a4225eff4d1a420613c4672d533d5de3b87d9d1de74d4151f6
+  md5: 93af5bb9bd715a830f23ae5d60d9efde
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 31139
+  timestamp: 1736207499907
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-builtin-interfaces-1.2.1-np126py311h2c3b307_7.conda
+  sha256: 2d5d8bdf8c6117bb5fb58a4e6e051e4afe8b1c2245dd6eb6af94f4fce74b2a96
+  md5: 86eee592f38f478d7bccc1c44136414d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 72866
+  timestamp: 1736209100802
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-builtin-interfaces-1.2.1-np126py311h65a17ee_5.conda
+  sha256: 7bceb74a7d1d0d3779cde001f692107527e5d251844594117f69f8a13adb77b3
+  md5: 80a31bb44532c46be3bd84f8fffa2dac
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 76602
+  timestamp: 1736211183653
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-class-loader-2.2.0-np126py311h2c3b307_7.conda
+  sha256: 42dbc7bea7e9708399d15fb78020a230895b4889f8a8d2d3c193b9a630ba18b2
+  md5: 73c40abac862f37bb7829a52c0f2f258
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 69991
+  timestamp: 1736208696437
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-class-loader-2.2.0-np126py311h65a17ee_5.conda
+  sha256: 502216d0d617035b46b3d51487afb160824adc625919e950ba5995a6a336c241
+  md5: 28fef3d7672f9bc0d26dca0a322c4c42
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 76254
+  timestamp: 1736209659360
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-common-interfaces-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 9e11170511ceeb46bc80db4a9170841488540702351258b91654ef0bc205afa1
+  md5: 2cf397053f15cf3ee3b0c7f522827ec1
+  depends:
+  - python
+  - ros-humble-actionlib-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-diagnostic-msgs
+  - ros-humble-geometry-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-shape-msgs
+  - ros-humble-std-msgs
+  - ros-humble-std-srvs
+  - ros-humble-stereo-msgs
+  - ros-humble-trajectory-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24430
+  timestamp: 1736210146596
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-common-interfaces-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 3417f13861f468ddf98199216fb6574c23f43a8e1a286715453982df3ab295a6
+  md5: b5e1dff99b82d71f2a270a56cfb49cbb
+  depends:
+  - python
+  - ros-humble-actionlib-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-diagnostic-msgs
+  - ros-humble-geometry-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-shape-msgs
+  - ros-humble-std-msgs
+  - ros-humble-std-srvs
+  - ros-humble-stereo-msgs
+  - ros-humble-trajectory-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 24432
+  timestamp: 1736213407423
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-composition-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 59e13e2247fbdcf15525408d5ce6390463507cc05157d4e7331e6abaa10a8cc8
+  md5: 92f783ef7410799034eeda2ebbf6bdce
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 329629
+  timestamp: 1736211379723
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-composition-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 5a49b74a612c396c0d80afd8ea550ab46b2eaf6ac38d5c4a903a46fb80046ed4
+  md5: 034c19ddc079eca8bfdb270fd3ea6348
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 328951
+  timestamp: 1736215119043
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-composition-interfaces-1.2.1-np126py311h2c3b307_7.conda
+  sha256: d13d6f840377179db1c67748abc1f72efdd0ca56c5a06242af5f63c22502ee77
+  md5: 9424fc9b5cb27f53c394d1c7e9976a18
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 144318
+  timestamp: 1736209370926
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-composition-interfaces-1.2.1-np126py311h65a17ee_5.conda
+  sha256: 7384371b6941a5f57227a2e33c1c268e9ba8c8ba720bb1f5bd12bf84dbe6b6e1
+  md5: 11b8cceb5f7de0c43a70de4ecad0068a
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 148054
+  timestamp: 1736211807160
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-console-bridge-vendor-1.4.1-np126py311h2c3b307_7.conda
+  sha256: b07b322e7989bf18e6620b1f7f7d264879b278a72f55932cdf237aa411314925
+  md5: ee1ebfe510641ab2d581b3aceb17bcd9
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24924
+  timestamp: 1736208487928
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-console-bridge-vendor-1.4.1-np126py311h65a17ee_5.conda
+  sha256: 1c1a7140ea724541ad98b22404ff291cbebf86e5d1d7893048b62ddbf35647b3
+  md5: c3d7ccd09888c0d95009678749a9ca9e
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  license: BSD-3-Clause
+  size: 24945
+  timestamp: 1736209005442
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-cv-bridge-3.2.1-np126py311h2c3b307_7.conda
+  sha256: f411eec3fe15a22157982d039a1029d74f3009b96813bc4b9c5093c915b3a6d6
+  md5: 36c6dc6b5c9553de57c1625774c44452
+  depends:
+  - libboost-python
+  - libopencv
+  - numpy
+  - py-opencv
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  license: BSD-3-Clause
+  size: 174919
+  timestamp: 1736209729884
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-cv-bridge-3.2.1-np126py311h65a17ee_5.conda
+  sha256: 39c2e5a8d7769c0c1497bb54a5a69f099ae630643862e0e95a422d329bd37626
+  md5: a53951c813b71bed26ad00c95c5c2a3a
+  depends:
+  - libboost-python
+  - libopencv
+  - numpy
+  - py-opencv
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
+  - libboost >=1.86.0,<1.87.0a0
+  - libopengl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 174153
+  timestamp: 1736212680289
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-cyclonedds-0.10.5-np126py311h2c3b307_7.conda
+  sha256: dea06c33ee49a50cee3864c7c5f3b16315fd5ad1f1dfe11ed791d2860dbe7ec3
+  md5: 78e1a3671b5ae1a9c497bd2d0be9c328
+  depends:
+  - openssl
+  - python
+  - ros-humble-iceoryx-binding-c
+  - ros-humble-iceoryx-hoofs
+  - ros-humble-iceoryx-posh
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - openssl >=3.4.0,<4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 1208705
+  timestamp: 1736207010593
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-cyclonedds-0.10.5-np126py311h65a17ee_5.conda
+  sha256: 1a535574d362c62dd721c55073a44b892b72753b9b55a144b5d6fb254361d496
+  md5: 0f8aa225367f95258195541e2fde8976
+  depends:
+  - openssl
+  - python
+  - ros-humble-iceoryx-binding-c
+  - ros-humble-iceoryx-hoofs
+  - ros-humble-iceoryx-posh
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - openssl >=3.4.0,<4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 1262923
+  timestamp: 1736207137569
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-cpp-0.20.5-np126py311h2c3b307_7.conda
+  sha256: a843604c8c5171714abce862d0e109999cb0584ab782586d40fa9401011a171a
+  md5: 96b544f022e8885843c03248feba820b
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-launch-xml
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 848452
+  timestamp: 1736211289537
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-cpp-0.20.5-np126py311h65a17ee_5.conda
+  sha256: aca8f86f4e7f36e4e4a2d362c2d670013c3b6e1fb47606713c6a5a97dd2fd5d0
+  md5: f1dc7f0a52f22af6bcf415a26367e8d9
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-launch-xml
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 865154
+  timestamp: 1736215038649
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-cpp-native-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 5ee3467f7df4484b550f19bc76f6d3b7ff04f8658f9244ed36d37ca0a9ccbf57
+  md5: f57821d0e5daf8cda9e61a971111a158
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rmw-fastrtps-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 115257
+  timestamp: 1736211276911
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-cpp-native-0.20.5-np126py311h65a17ee_5.conda
+  sha256: c66b5b5bb8bf6100c1af560d486fe2905bd42e387db2802e85e03a25880eed83
+  md5: e858a5f9f9f708421049d33ce3f5843d
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rmw-fastrtps-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 117837
+  timestamp: 1736214990416
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-demo-nodes-py-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 3cc0e409153a4534ea8aad3f13e1a15e04db2d81d23be97a8f7f3b2823507013
+  md5: aac788444be6b831229b91f506ccea3b
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 26610
+  timestamp: 1736210465331
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-demo-nodes-py-0.20.5-np126py311h65a17ee_5.conda
+  sha256: ee7cef5b2fc7a61ee5ec1cb4c3b56374a5fbe6117f60f4ce8eaca41889ef5300
+  md5: b6b5f5574c78b7948cf2f065f897a9f3
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 26596
+  timestamp: 1736214192159
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-depthimage-to-laserscan-2.5.1-np126py311h2c3b307_7.conda
+  sha256: 2990c0d05062efe773b5eb9ed17de1d7ed1d8b474d976a4f115bd651e96d5553
+  md5: 78b8e8e58182d35ba8e69290f5cc3d81
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-image-geometry
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  license: BSD-3-Clause
+  size: 235510
+  timestamp: 1736210578975
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-depthimage-to-laserscan-2.5.1-np126py311h65a17ee_5.conda
+  sha256: f19ab473c6fd20812e0e6e0530d9f9e6c9e290558def1100081ffcc1feeb9010
+  md5: ff21bf6353cf24e1de6e3f6c8bebf253
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-image-geometry
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - py-opencv >=4.10.0,<5.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 228436
+  timestamp: 1736214571660
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-desktop-0.10.0-np126py311h2c3b307_7.conda
+  sha256: ba4480be965ac44ae8410a87550ee278c13c82b12508977b2b3fef551bd3ffe7
+  md5: 41344f25710efd15d912f4188c084d0f
+  depends:
+  - python
+  - ros-humble-action-tutorials-cpp
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-action-tutorials-py
+  - ros-humble-angles
+  - ros-humble-composition
+  - ros-humble-demo-nodes-cpp
+  - ros-humble-demo-nodes-cpp-native
+  - ros-humble-demo-nodes-py
+  - ros-humble-depthimage-to-laserscan
+  - ros-humble-dummy-map-server
+  - ros-humble-dummy-robot-bringup
+  - ros-humble-dummy-sensors
+  - ros-humble-examples-rclcpp-minimal-action-client
+  - ros-humble-examples-rclcpp-minimal-action-server
+  - ros-humble-examples-rclcpp-minimal-client
+  - ros-humble-examples-rclcpp-minimal-composition
+  - ros-humble-examples-rclcpp-minimal-publisher
+  - ros-humble-examples-rclcpp-minimal-service
+  - ros-humble-examples-rclcpp-minimal-subscriber
+  - ros-humble-examples-rclcpp-minimal-timer
+  - ros-humble-examples-rclcpp-multithreaded-executor
+  - ros-humble-examples-rclpy-executors
+  - ros-humble-examples-rclpy-minimal-action-client
+  - ros-humble-examples-rclpy-minimal-action-server
+  - ros-humble-examples-rclpy-minimal-client
+  - ros-humble-examples-rclpy-minimal-publisher
+  - ros-humble-examples-rclpy-minimal-service
+  - ros-humble-examples-rclpy-minimal-subscriber
+  - ros-humble-image-tools
+  - ros-humble-intra-process-demo
+  - ros-humble-joy
+  - ros-humble-lifecycle
+  - ros-humble-logging-demo
+  - ros-humble-pcl-conversions
+  - ros-humble-pendulum-control
+  - ros-humble-pendulum-msgs
+  - ros-humble-quality-of-service-demo-cpp
+  - ros-humble-quality-of-service-demo-py
+  - ros-humble-ros-base
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-common-plugins
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz2
+  - ros-humble-teleop-twist-joy
+  - ros-humble-teleop-twist-keyboard
+  - ros-humble-tlsf
+  - ros-humble-tlsf-cpp
+  - ros-humble-topic-monitor
+  - ros-humble-turtlesim
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22062
+  timestamp: 1736215434120
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-desktop-0.10.0-np126py311h65a17ee_5.conda
+  sha256: 18a7c51ad0980560781ad220ffe88f0774f4da73bef7f703d513288f56af2708
+  md5: 98af4042e81072bfcb77ac4085647d31
+  depends:
+  - python
+  - ros-humble-action-tutorials-cpp
+  - ros-humble-action-tutorials-interfaces
+  - ros-humble-action-tutorials-py
+  - ros-humble-angles
+  - ros-humble-composition
+  - ros-humble-demo-nodes-cpp
+  - ros-humble-demo-nodes-cpp-native
+  - ros-humble-demo-nodes-py
+  - ros-humble-depthimage-to-laserscan
+  - ros-humble-dummy-map-server
+  - ros-humble-dummy-robot-bringup
+  - ros-humble-dummy-sensors
+  - ros-humble-examples-rclcpp-minimal-action-client
+  - ros-humble-examples-rclcpp-minimal-action-server
+  - ros-humble-examples-rclcpp-minimal-client
+  - ros-humble-examples-rclcpp-minimal-composition
+  - ros-humble-examples-rclcpp-minimal-publisher
+  - ros-humble-examples-rclcpp-minimal-service
+  - ros-humble-examples-rclcpp-minimal-subscriber
+  - ros-humble-examples-rclcpp-minimal-timer
+  - ros-humble-examples-rclcpp-multithreaded-executor
+  - ros-humble-examples-rclpy-executors
+  - ros-humble-examples-rclpy-minimal-action-client
+  - ros-humble-examples-rclpy-minimal-action-server
+  - ros-humble-examples-rclpy-minimal-client
+  - ros-humble-examples-rclpy-minimal-publisher
+  - ros-humble-examples-rclpy-minimal-service
+  - ros-humble-examples-rclpy-minimal-subscriber
+  - ros-humble-image-tools
+  - ros-humble-intra-process-demo
+  - ros-humble-joy
+  - ros-humble-lifecycle
+  - ros-humble-logging-demo
+  - ros-humble-pcl-conversions
+  - ros-humble-pendulum-control
+  - ros-humble-pendulum-msgs
+  - ros-humble-quality-of-service-demo-cpp
+  - ros-humble-quality-of-service-demo-py
+  - ros-humble-ros-base
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-common-plugins
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz2
+  - ros-humble-teleop-twist-joy
+  - ros-humble-teleop-twist-keyboard
+  - ros-humble-tlsf
+  - ros-humble-tlsf-cpp
+  - ros-humble-topic-monitor
+  - ros-humble-turtlesim
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22001
+  timestamp: 1736220923079
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-diagnostic-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 5e321107092de710d4aed553f2f7a9247043398564cc85dd3f3152e4ea488f21
+  md5: b5ef8b6a73455eb1f41227f3d663275d
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 144442
+  timestamp: 1736209495666
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-diagnostic-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: fc4c334966dd6f9d2a7e745b5db657aad3aeec0c2cc20d77a10afa40ec027d58
+  md5: 0d66c15cdcc25ce48e46998f39be9624
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 147862
+  timestamp: 1736212035394
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-domain-coordinator-0.10.0-np126py311h2c3b307_7.conda
+  sha256: 8b1fb60edca06f7a4d6319391df40ae6ce0fde4325337c2a8c654a1014653e1e
+  md5: e2753ddd9c03cea55d3ebffd1452d2d8
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 19808
+  timestamp: 1736207095317
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-domain-coordinator-0.10.0-np126py311h65a17ee_5.conda
+  sha256: 2c6c57e2eb36b1d5084b9be8ab7ca53d0406d00daedbcfff339901fd8bcd18e2
+  md5: 7184d84cc509baf247e4751cca51eb1c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 19792
+  timestamp: 1736207301429
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-map-server-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 9295a46f55664707220946a66993f7ad0fed5f0a7021cf8d17b3b7758c8018c8
+  md5: 9bf3debe4631ee563fce75fe5d9bea0b
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 84954
+  timestamp: 1736210453656
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-map-server-0.20.5-np126py311h65a17ee_5.conda
+  sha256: ef916e859557975133b6ab246678698f7017dc0e705c5991baa509c9b68185b8
+  md5: 0048cd760fbee9baee1aa4379c1064bb
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 91630
+  timestamp: 1736214159825
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-robot-bringup-0.20.5-np126py311h2c3b307_7.conda
+  sha256: bd055f5faa4fe6d043e5fc89b74d7bf3e6590b41b33d65450f40626b9151e163
+  md5: 9bcd2703edc87e2c2f6fff42349cb5ef
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-dummy-map-server
+  - ros-humble-dummy-sensors
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-robot-state-publisher
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 28615
+  timestamp: 1736212045258
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-robot-bringup-0.20.5-np126py311h65a17ee_5.conda
+  sha256: cf03694cf79bd60904f5f0dcbe4ebcfdc2f69aece7cdd30dbf629f45470f9fde
+  md5: 1dd2ab997228b1045c7f5eb20c8da50c
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-dummy-map-server
+  - ros-humble-dummy-sensors
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-robot-state-publisher
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 28641
+  timestamp: 1736215747734
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-dummy-sensors-0.20.5-np126py311h2c3b307_7.conda
+  sha256: b1bd6749ecf455eb105cd926146fc270bf874f6a5bfd9bee78676822260f2291
+  md5: 605a15b353548fd6187ef27d07738971
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 112464
+  timestamp: 1736210440401
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-dummy-sensors-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 17fd508ee43aa184208283dfd619adeb2e8f0f333b2922a4e427d25bb3630f59
+  md5: 2a42217a91d803a099999cbc05216fdb
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 114239
+  timestamp: 1736214124268
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h2c3b307_7.conda
+  sha256: 3c7e72f4d291050a517134afb2027fb4c33ff08eda40560bb170502e609e62dc
+  md5: 1e600abdbb322a07723876b96027575b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21981
+  timestamp: 1736207496761
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-eigen3-cmake-module-0.1.1-np126py311h65a17ee_5.conda
+  sha256: dfb21941a2a45d459eb7a2906909e924858db5df3f34db205894dcb5f0fe33bf
+  md5: d386839d5912525fef6ce32679cecde1
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21904
+  timestamp: 1736207920804
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-example-interfaces-0.9.3-np126py311h2c3b307_7.conda
+  sha256: af775ce69d2347813213bd5b509b61789a9d47704fae82717bcbb59176c53ebb
+  md5: bb028834fb2af41d6c3ed99de4cb8983
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 379993
+  timestamp: 1736209358990
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-example-interfaces-0.9.3-np126py311h65a17ee_5.conda
+  sha256: 1521d6c3fb797463abdb948c798613d793ab6d617d588540ddcf3e73a8e86e19
+  md5: b0126b8eb8e2230a5da68016c1cfe022
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 382951
+  timestamp: 1736211788797
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-action-client-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 511429e9536159ae3012a3b9ae5562d846ce0f112edbc7d729623b8d29f65039
+  md5: 5e27ee391a687d195d51c54fbe3132eb
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 147677
+  timestamp: 1736210731993
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-action-client-0.15.3-np126py311h65a17ee_5.conda
+  sha256: b7d88925ee2ad5ade7ad2c6234c4e2168baefc95cbb6cf3ed2f1fbfca5593741
+  md5: 0273488f249bb02346b8576eb8bbd292
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 152773
+  timestamp: 1736214539766
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-action-server-0.15.3-np126py311h2c3b307_7.conda
+  sha256: c91bd600f2f0014211393530188e3ddcea287b42c750f5b297b15625ad8885f0
+  md5: f6bda7ac02d2f1b7a5c25394bd2fc653
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 83444
+  timestamp: 1736210721023
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-action-server-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 35c535a3466d4f993cc9ff8e827392b1018fa885dab7d847c4c99c4958f419a8
+  md5: 7d270cf1b87925178230255001cd8598
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 88694
+  timestamp: 1736214506271
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-client-0.15.3-np126py311h2c3b307_7.conda
+  sha256: dc4420b18bfe50b96ed454b639d6eb0b05b651947cad6cd68542120f4a1dc0a4
+  md5: b50de860380ab35fa381550008355530
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 65310
+  timestamp: 1736210473655
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-client-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 8e0ffa3888e0bbed2eb5fa6860e969d18d2330c6725dee85d5b0a6b1f2fdc655
+  md5: 0295076845e9e9efdad4bcb74da46b3e
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 66569
+  timestamp: 1736214137525
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-composition-0.15.3-np126py311h2c3b307_7.conda
+  sha256: e78434e68121036c7ecbd74a0b9524fd25eee841d9bf6c157201a57e90ed1e2e
+  md5: 03695aeafde750faf521f190c1d68b7e
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 191442
+  timestamp: 1736210701933
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-composition-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 46eb2c75a73e7a97b5d15cf6611bdc4ab3616e631553c1e3a336f3f6b8ffd5e3
+  md5: a001298fead9550e66d320ed2d3c9674
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 190336
+  timestamp: 1736214448881
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-publisher-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 8b52ab92c2c8b62d6dbf116441c78afa8c8a3f0c3c5a334a34bc64ae122dce87
+  md5: 16d4defc737c5fc150f2f56ee0d3bd1e
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 189718
+  timestamp: 1736210454909
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-publisher-0.15.3-np126py311h65a17ee_5.conda
+  sha256: d1fe1d9bc5548107b0517a275b15575842073786fb091adc1788ba859edf89b5
+  md5: ce38b7471ad4ddb86af81ceb66a192f2
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 195400
+  timestamp: 1736214103947
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-service-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 7e5c3570d9a54dca70cd1791548233d20e21cee026a0e7e5bc154727863602e6
+  md5: 45ef91776c1e12c27595a41a5ec2c090
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 56634
+  timestamp: 1736210444970
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-service-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 315f8630260c6d2667f99c43ce75a18bf8c7c6b0081e66d505d87b804d441c8f
+  md5: 56a046950d1de4ad395537675ba9957d
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 57906
+  timestamp: 1736214066417
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-subscriber-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 5656fe41c5b4f3df8e789a584822c5b2780479a4c30b94c58240be379497ba5c
+  md5: dc7fc7f43b89d508b0efd2d25bfb4431
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 556608
+  timestamp: 1736210647945
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-subscriber-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 437eb2019f0865373c711fc3827c165ddb2171354a98c2538ef7cbbf5b0b76ad
+  md5: 98b376bb4571cd7de5b586a34304a876
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 569507
+  timestamp: 1736214677449
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-minimal-timer-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 505b113ff51aeb0d49c89f6a38f7addd0f9336a6e105ef9ed4f82a6b0abb8705
+  md5: 481123cda02dc6175a30c24cbf9c4ac4
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 47196
+  timestamp: 1736210436235
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-minimal-timer-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 4dd84ae202066fe97c85de05f490ecd8641fc092f5179bd9c159b832d0dbee38
+  md5: 8b173eaa451e2b7d8c8ab36388fb80fd
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 48593
+  timestamp: 1736214148184
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclcpp-multithreaded-executor-0.15.3-np126py311h2c3b307_7.conda
+  sha256: dffcb0080ead2c20ee1b053fdc7bf4190d36d58ad9dbb8eccaf3f5d3df721b27
+  md5: 29591886086616c3cd576b8dba60f3c0
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 164896
+  timestamp: 1736210411954
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclcpp-multithreaded-executor-0.15.3-np126py311h65a17ee_5.conda
+  sha256: ec48ecea69d24ad0c82685eba652b615c7c5ddca0670a42cf0c7c705ecebff3f
+  md5: 4b22b71176c96cf3f0f65f428236bb86
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 163976
+  timestamp: 1736214098459
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-executors-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 68d3deafda81ea53f33245a1b0b04fc58a6284dd4d6c35598dadef23acfe25f5
+  md5: 934f5d3877f4de320cff753fc64cd736
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27125
+  timestamp: 1736210431195
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-executors-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 77ecc4f315366ebd6bf801873ec19cc22ba0e98d71866468e53a11ae5993a652
+  md5: 0f728383ef779bdbc1d959e9d92503f6
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27068
+  timestamp: 1736214090715
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-action-client-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 3fff6e5bee481e4f2627b8a0e86a03da48812b7b09c2924bf479044906300480
+  md5: 31653ee2e390cfb88af080e8ec31e432
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25377
+  timestamp: 1736210427537
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-action-client-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 70f935ebff92c37d2fe848f741852ce710964709a0a8330985bf3fe303e3a758
+  md5: cf50ec7417c55f10fc6562ead87e9f18
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 25365
+  timestamp: 1736214082760
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-action-server-0.15.3-np126py311h2c3b307_7.conda
+  sha256: dada668fed298aa921ca3898a22c980413ede3dff22b5f31052ad72344bcee42
+  md5: 922a17e6b9b606ac3a4bebc0d3429575
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 26853
+  timestamp: 1736210423886
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-action-server-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 44fe20aa536ae9aaa9dc8e0e7d6e31cf2269f8a3e07d81d093dc6919769af648
+  md5: e423fe53d3806143f7f5b9792e099e3d
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 26834
+  timestamp: 1736214066220
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-client-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 3fdf617b03f54bf1668706af5405f6f1c4ae3dc3de84893aa43da329f6b6c7bd
+  md5: c0a16be7843ea956dc09c863b4947516
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22481
+  timestamp: 1736210420289
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-client-0.15.3-np126py311h65a17ee_5.conda
+  sha256: d4b42cae7a4499ec59e3aaf9959f48a5cfe764da37138ea0afa8b380c2fa3280
+  md5: 35843eb7235d7661713f97dde62e0850
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22431
+  timestamp: 1736214163159
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-publisher-0.15.3-np126py311h2c3b307_7.conda
+  sha256: f70c7dd3dfc7955e3165b94aef360c6c7bff4b63de042b61be74e0751afa5ac2
+  md5: 34e0efa742aaa36601f886d4ac4394c4
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21265
+  timestamp: 1736210410193
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-publisher-0.15.3-np126py311h65a17ee_5.conda
+  sha256: eb09e4d325301818aab8f9476c10c35a1bd0b04090c5f9727df29bdaf7a62197
+  md5: 5a3c4609ec2c2ac2c8f4368ea5070aaa
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21220
+  timestamp: 1736214155680
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-service-0.15.3-np126py311h2c3b307_7.conda
+  sha256: 7094d8e60e8fa4f248bb5d78bfbc0d5a3143e7e2c5247aa04a338192f00a80f4
+  md5: 1a0964e8d6c67962cf0b059d050716c6
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20160
+  timestamp: 1736210482973
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-service-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 2ff4626eef7fb019ac2e2efaf131848b625e70a836dc4f0dfb99857ee45870c2
+  md5: efb42b612b4e78ae8b277802bc89d377
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20112
+  timestamp: 1736214148259
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-examples-rclpy-minimal-subscriber-0.15.3-np126py311h2c3b307_7.conda
+  sha256: e196f28e9089bc4461733c42ee578c1b8881cfc324b34c6e8bc7848ecfeda4cf
+  md5: 954d081074f2b3d00dd7d240f345d43e
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20758
+  timestamp: 1736210478066
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-examples-rclpy-minimal-subscriber-0.15.3-np126py311h65a17ee_5.conda
+  sha256: 7843122f2ecaf53d70ec328ff81c100d6b8e7c3f43e6e442e258046457395bd6
+  md5: 07910c3ec8eca93dcc882aaadf0f2f07
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20726
+  timestamp: 1736214138381
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastcdr-1.0.24-np126py311h2c3b307_7.conda
+  sha256: 9ce292efa7fd3bcfa46588ffd97bf10eaab68868dd26343c4e8d733e542320ee
+  md5: 64e89087daf71b4ba149c9d36d2e0956
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 65965
+  timestamp: 1736205360422
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastcdr-1.0.24-np126py311h65a17ee_5.conda
+  sha256: 7aa80ec001f0263b2a3ab7025d2211582fd9044138a2b783854eb9f4118af4f8
+  md5: a33b15ba6711047fb9db3e1d1b018255
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 63059
+  timestamp: 1736205783254
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-2.6.9-np126py311h2c3b307_7.conda
+  sha256: ab27ecedbb6daa3a9279dd4a3f30c4232b1e9f6d362c000e52f71816aed7ad3d
+  md5: a84e4173c3c42bfa39e0fdfd8930db45
+  depends:
+  - openssl
+  - python
+  - ros-humble-fastcdr
+  - ros-humble-foonathan-memory-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml2
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - openssl >=3.4.0,<4.0a0
+  - python_abi 3.11.* *_cp311
+  - tinyxml2 >=10.0.0,<11.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 3689820
+  timestamp: 1736208182246
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-2.6.9-np126py311h65a17ee_5.conda
+  sha256: 32ef8beb660471902c926ad8523f5d7fcd3576bf17959f083b688f5dbcf48e57
+  md5: c031fbbe8db6daad913ab308625a2be8
+  depends:
+  - openssl
+  - python
+  - ros-humble-fastcdr
+  - ros-humble-foonathan-memory-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml2
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 3543563
+  timestamp: 1736208534083
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h2c3b307_7.conda
+  sha256: f33b599bb53ae0213dd9d54a91cb58f0c67cea4170d9912c4260272ca8d63554
+  md5: 6ab94c87b6d06d78b76fdc99cc538379
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25170
+  timestamp: 1736208177863
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-fastrtps-cmake-module-2.2.2-np126py311h65a17ee_5.conda
+  sha256: 0b3ab5b7abd577c0222edad3380931867774bd12b5c55e56200cffbf4f6d2db8
+  md5: e27f68da4458513d0d1b041f17258b63
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25201
+  timestamp: 1736208523799
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h2c3b307_7.conda
+  sha256: dc0c9b825ec3ef343657c88bfcdb2113973ffac58cc3424eee2cef22b17596fb
+  md5: 009e93a727744a6c53f718fe8b318804
+  depends:
+  - cmake
+  - foonathan-memory
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - foonathan-memory >=0.7.3,<0.7.4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 18428
+  timestamp: 1736207558068
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-foonathan-memory-vendor-1.2.0-np126py311h65a17ee_5.conda
+  sha256: 57a8fcb86225fd1a7dfc32ffaa4b0ceead42aeacc6f66a4e1e5fc7f92c476ce6
+  md5: 5939f70d02aef955ee646af643273173
+  depends:
+  - cmake
+  - foonathan-memory
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - foonathan-memory >=0.7.3,<0.7.4.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 18508
+  timestamp: 1736208067471
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 5c8e2795ce033322eb101ca70ba3f3f13013048e32c81eb9fc57ab19b5252be7
+  md5: 03ed2e763e19685b4579019ed8c7b918
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 298963
+  timestamp: 1736209385594
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-geometry-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 49b70dd1d8e91d675a350f22fed9676a9d0201a637223c2351168832808d437d
+  md5: 4f5521172098c03543f9bb2fe0ed281f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 304262
+  timestamp: 1736211833914
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-geometry2-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 384532b59ca4347103dd01db9391c340b0df22c2ee71987e3f71109a6f33ebe7
+  md5: 687ba2097131c3db7bf12866c6e1192f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-bullet
+  - ros-humble-tf2-eigen
+  - ros-humble-tf2-eigen-kdl
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-kdl
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-sensor-msgs
+  - ros-humble-tf2-tools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20909
+  timestamp: 1736212117625
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-geometry2-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 393cdae34abfdda10e86d4765a3d70f2c6719745176372be5c7dbb7868a34ed2
+  md5: a2a9d49dbf389643dfe1a6929c3ea09f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-bullet
+  - ros-humble-tf2-eigen
+  - ros-humble-tf2-eigen-kdl
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-kdl
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-sensor-msgs
+  - ros-humble-tf2-tools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20846
+  timestamp: 1736215854504
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gmock-vendor-1.10.9006-np126py311h2c3b307_7.conda
+  sha256: 6e745bfc64adde2254dbd03167be77b3b19e4997dbd81b817b73e16f63a5e57b
+  md5: adbb4d01192a0586c5b1c6e5cef017e0
+  depends:
+  - python
+  - ros-humble-gtest-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 112835
+  timestamp: 1736206845288
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gmock-vendor-1.10.9006-np126py311h65a17ee_5.conda
+  sha256: 87bd2c8b721d39ab60aad80d1fb88ef3f367a88ed0da077288caed633c9665f7
+  md5: cd6327648617563c1171b1fd3c333335
+  depends:
+  - python
+  - ros-humble-gtest-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 112823
+  timestamp: 1736206720433
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-gtest-vendor-1.10.9006-np126py311h2c3b307_7.conda
+  sha256: 2002ad1acf1b4aaf571f5eb356d96b40ac27ad6329f6cf8742f2561c17791428
+  md5: eb25b0ccf69f820fbcf1dd59217950ff
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 199218
+  timestamp: 1736205370054
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-gtest-vendor-1.10.9006-np126py311h65a17ee_5.conda
+  sha256: e406f9437a0cec1d9c672100e9fa935cd89d8ee57c83ad9d09edd6e679eb8e68
+  md5: dabb97b08de7672919ecbf99a750f9c5
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 199172
+  timestamp: 1736205789902
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h2c3b307_7.conda
+  sha256: fa41746dcf44cd7be420d92f37349feee786d59ad94317ebda352c49ec1c91a0
+  md5: 3e091d9261c88114e8956f86d7a005cc
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 91935
+  timestamp: 1736206921266
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-binding-c-2.0.5-np126py311h65a17ee_5.conda
+  sha256: b6aa7441658b7993e01242bd4b19ab5c2be6a96cc7e750276155bc2315620740
+  md5: f8aa50a37d74cae7fe2fcbb31995e64d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 90310
+  timestamp: 1736206921290
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h2c3b307_7.conda
+  sha256: fb294d9f14e1568cf929db2dafb28dca242b0dcc6ad955b12797b2d80e37f046
+  md5: 9005953fc6a519ab808c0d846ed5bd19
+  depends:
+  - libacl
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libacl >=2.3.2,<2.4.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 265904
+  timestamp: 1736205366416
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-hoofs-2.0.5-np126py311h65a17ee_5.conda
+  sha256: b31ce87590546b9d007512f3d1ef50803d9820d430e050eb9289765362517fb8
+  md5: db177511c063e3b9d8beb581ba0a540f
+  depends:
+  - libacl
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - libacl >=2.3.2,<2.4.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 265719
+  timestamp: 1736205796682
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-iceoryx-posh-2.0.5-np126py311h2c3b307_7.conda
+  sha256: 7890f0ef1007b02328fc65ff6c6b225b8692ae64bb1bd3a67c8004bce7fae862
+  md5: 098bc41d1d9526de7350d5797ad245db
+  depends:
+  - python
+  - ros-humble-iceoryx-hoofs
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 578521
+  timestamp: 1736206849204
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-iceoryx-posh-2.0.5-np126py311h65a17ee_5.conda
+  sha256: 90ad8d598554dafd4bc0c464b489d0cb555ff551606941fb64da836774544b8e
+  md5: ebc7231eb8655072829c518a137a1a0f
+  depends:
+  - python
+  - ros-humble-iceoryx-hoofs
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 582152
+  timestamp: 1736206728413
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h2c3b307_7.conda
+  sha256: 87e4c55ebed9c2833e71f001f6418dbfb3698f99375ae355755fd7c936021ce8
+  md5: af96d5bab1c8b7a7e26b0e47231fbeab
+  depends:
+  - libignition-cmake2
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - graphviz >=12.0.0,<13.0a0
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22863
+  timestamp: 1736208126971
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ignition-cmake2-vendor-0.0.2-np126py311h65a17ee_5.conda
+  sha256: 4bfc32ae5a001261636204a798e2d19dfe75035e30fbf404f50443013e5dbf97
+  md5: 75e8e120eb0ada3dbe36cbcf1d96ee98
+  depends:
+  - libignition-cmake2
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - graphviz >=12.0.0,<13.0a0
+  - libignition-cmake2 >=2.17.2,<3.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 23766
+  timestamp: 1736208371603
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h2c3b307_7.conda
+  sha256: fb80366dbf9affa275ddd1ec5c5d83d83856746a9d28ea6d68d61343d5e6d48a
+  md5: 764b99e49096a1639081bae5b23c75a6
+  depends:
+  - libignition-math6
+  - python
+  - ros-humble-ignition-cmake2-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libignition-math6 >=6.15.1,<7.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22724
+  timestamp: 1736208176604
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ignition-math6-vendor-0.0.2-np126py311h65a17ee_5.conda
+  sha256: a6816a4ac15222673d81f50088d628c5933cf6d67256691da54c5eb79ad51586
+  md5: 93b865276ee71088c003275f09846a63
+  depends:
+  - libignition-math6
+  - python
+  - ros-humble-ignition-cmake2-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - libignition-math6 >=6.15.1,<7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22607
+  timestamp: 1736208528447
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-geometry-3.2.1-np126py311h2c3b307_7.conda
+  sha256: 93d3a7da6a6862d0424ee9d4bfcfd087e00357ff4cb18d67839bc4436bfb3faa
+  md5: 0b54b87cd22c904e7b7229c4c7342453
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  license: BSD-3-Clause
+  size: 73178
+  timestamp: 1736209743381
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-geometry-3.2.1-np126py311h65a17ee_5.conda
+  sha256: 7ec9ac9870814aa8fdfa2e308528aab12baa53f45dade0d60b824390a28c0693
+  md5: 951c3f98a34694c012e5ccc8fd7e0126
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - py-opencv >=4.10.0,<5.0a0
+  license: BSD-3-Clause
+  size: 68339
+  timestamp: 1736212493424
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-tools-0.20.5-np126py311h2c3b307_7.conda
+  sha256: fba8c8c358f09d5a97d1552e538190fc31ac00af11ecbec849993a159be07877
+  md5: f969b847dbf1a2bbe164e9bcbd59b5fb
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 290795
+  timestamp: 1736211249005
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-tools-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 16369889af2abd26f4397c80dafcd4568dc35072c3e9386bbb4d7120508f1fcc
+  md5: f986e3e53751ba6cfa64201c3ec3a7d1
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 284311
+  timestamp: 1736215064407
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-image-transport-3.1.10-np126py311h2c3b307_7.conda
+  sha256: 9afd15b17faa8631c2d3250bb80d0bab9dd1bad59a926116cad44725a5118032
+  md5: f49b17afe8b8b7bc7d4082dafc2d4744
+  depends:
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 558250
+  timestamp: 1736210939243
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-image-transport-3.1.10-np126py311h65a17ee_5.conda
+  sha256: 8dc53d609153b29ee29e98e84f700373d78bea147d61ad6a4169fd823d0af217
+  md5: d6bfbc035b962d1e145d17d6ffbe2cc6
+  depends:
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 561430
+  timestamp: 1736214977432
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-interactive-markers-2.3.2-np126py311h2c3b307_7.conda
+  sha256: f67305f3ba1dbd8bc42fa29df62f06fae7cf89d4bb7e94f26eeaae9432a8664c
+  md5: 882ff76314900b20851d22d7f9f8557d
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 311725
+  timestamp: 1736212173111
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-interactive-markers-2.3.2-np126py311h65a17ee_5.conda
+  sha256: 9b3aa6a80f8ebd9ef8fa2cc57bf349eca04b591c874404f332baa0efcb9438d9
+  md5: 53dd6b778426ea39b0fc4b90c0345919
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 310801
+  timestamp: 1736215846540
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-intra-process-demo-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 46241b2e70167ad7c09fb4f1a838cb81dcfe7689a1ac103d72b0ecf3dfb90ea1
+  md5: 71e19de790d03432e47eba0af6528d81
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libopengl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 518600
+  timestamp: 1736210431461
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-intra-process-demo-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 24e1553d9d661a7a726e31ef8caca7a77603a534c14843b0693f0b1a62e2cb45
+  md5: c824be31903376f7ceb77dd6786e2a1e
+  depends:
+  - libopencv
+  - py-opencv
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - py-opencv >=4.10.0,<5.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 515579
+  timestamp: 1736214064247
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-joy-3.3.0-np126py311h2c3b307_7.conda
+  sha256: 556a7c2729d8530ea389d5e165f7291cc583e4044db8d678311d20c8822e6c6f
+  md5: 5a092cc58a7ce9cd30640e87b411a456
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sdl2-vendor
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 273882
+  timestamp: 1736210615541
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-joy-3.3.0-np126py311h65a17ee_5.conda
+  sha256: a3e950c2516e4499270bd6a86c45ad19ae7166902c2b2674e0da798c761de507
+  md5: 855085e691c3383bfa1efc740ad60dd3
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sdl2-vendor
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 269590
+  timestamp: 1736214529828
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-kdl-parser-2.6.4-np126py311h2c3b307_7.conda
+  sha256: 8ff2d51c7e29f1a9678e9260aa07145a41e39935293f71c9cad3328b2f83b659
+  md5: c020caded3011ff328847f3809cca230
+  depends:
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-urdf
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 44709
+  timestamp: 1736208942905
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-kdl-parser-2.6.4-np126py311h65a17ee_5.conda
+  sha256: fe15418553e1c1640112da917169acadd7d0d72dca02db99332c0aa446bea375
+  md5: c7ee0e32928521b7356a7fd911b1946f
+  depends:
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-urdf
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45904
+  timestamp: 1736210641120
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-keyboard-handler-0.0.5-np126py311h2c3b307_7.conda
+  sha256: ddb1d8c3c0b002e53d3b7fc90ca64241bb97ce005db5645cfeffba333fe50d4f
+  md5: a15dbe2ba162e61f6dbf79089b4fff74
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 53516
+  timestamp: 1736208187282
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-keyboard-handler-0.0.5-np126py311h65a17ee_5.conda
+  sha256: de906ad8eec414484c2fb1224604e9f16720d5fc5fd8c005472baf2219737976
+  md5: ecd2448e02cce1dd2b82059b356cab58
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 54791
+  timestamp: 1736208549780
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-laser-geometry-2.4.0-np126py311h2c3b307_7.conda
+  sha256: 16570ba41be209ec1d073abb7bd1c8ac22a5092981ad5d92fa6adef44b78a2ef
+  md5: bf499b5a0f15e19e8d07a86054a62ebb
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-sensor-msgs-py
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 56990
+  timestamp: 1736210411778
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-laser-geometry-2.4.0-np126py311h65a17ee_5.conda
+  sha256: 0e5656bf5050b9e84564486cd271ea3740d529a17932d2b10beb4cfb0f3f279b
+  md5: 881912ddee11c35e258318d84edba6db
+  depends:
+  - eigen
+  - numpy
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-sensor-msgs-py
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 56312
+  timestamp: 1736214058813
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-1.0.7-np126py311h2c3b307_7.conda
+  sha256: 46d0b6ef86bcfa5701cd15bf83ea708745db953bba0ae2c6a19cbff5e7ec080c
+  md5: 361e826595ab7a9dcb4d57971ed77aef
+  depends:
+  - importlib-metadata
+  - lark-parser
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-osrf-pycommon
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 224312
+  timestamp: 1736207184982
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-1.0.7-np126py311h65a17ee_5.conda
+  sha256: 361f9f72dff3e81a75fb47eef45b6b00895776b2249888731dba3850b9125f1c
+  md5: 4674d8cb9f371886a8d75dbd640f49fd
+  depends:
+  - importlib-metadata
+  - lark-parser
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-osrf-pycommon
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 224287
+  timestamp: 1736207501166
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-ros-0.19.8-np126py311h2c3b307_7.conda
+  sha256: 27065230af004e4d7d14ada51dd999234b4b7e9ee87be6f70e044c9f2e4b1ec6
+  md5: 4699fb1043e7a0b5f77e80d29a9c32c0
+  depends:
+  - importlib-metadata
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-composition-interfaces
+  - ros-humble-launch
+  - ros-humble-lifecycle-msgs
+  - ros-humble-osrf-pycommon
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 114607
+  timestamp: 1736210412266
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-ros-0.19.8-np126py311h65a17ee_5.conda
+  sha256: 4dba761c581b99ac08d4605740da6c98e94856c5a8303c60f71d80f2bb366b8b
+  md5: 1cc1b8b9ab3a44e0b3ad88bcb3444c9e
+  depends:
+  - importlib-metadata
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-composition-interfaces
+  - ros-humble-launch
+  - ros-humble-lifecycle-msgs
+  - ros-humble-osrf-pycommon
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 114505
+  timestamp: 1736214062303
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-1.0.7-np126py311h2c3b307_7.conda
+  sha256: ead8b0e478b6a8b4ad223de2fbf608bd5f23e7574c226d32de584677565cf59d
+  md5: d2d7d34750ba222db776c6786d91e98b
+  depends:
+  - pytest
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-launch
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-osrf-pycommon
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 117194
+  timestamp: 1736207491044
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-1.0.7-np126py311h65a17ee_5.conda
+  sha256: b618cc2b139ccf74e6d9b5b355b43f8dfe1fa2201f9bec2148a19d95641ea8ba
+  md5: 95b1727bd325d11de0e96c58be201b71
+  depends:
+  - pytest
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-launch
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-osrf-pycommon
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 117152
+  timestamp: 1736207907586
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h2c3b307_7.conda
+  sha256: 1c04e2cc953cf784d33803c94c04f9d78072b4b841e6076e9874477e5e3aa593
+  md5: bf667f8cdfc0821fa6b469414ecc9e17
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-launch-testing
+  - ros-humble-python-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25451
+  timestamp: 1736208465768
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-ament-cmake-1.0.7-np126py311h65a17ee_5.conda
+  sha256: 984edddb31902ea4800f84ea3b68fd70c14f5cb20abe50b15e6e56b0c5ec2213
+  md5: 625e8c89b111c23471ec4a04eaa7a694
+  depends:
+  - python
+  - ros-humble-ament-cmake-test
+  - ros-humble-launch-testing
+  - ros-humble-python-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25385
+  timestamp: 1736208946593
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-testing-ros-0.19.8-np126py311h2c3b307_7.conda
+  sha256: 43d719e0995cd2499c7ceae5bdb10032571b8bb3cac92f621bb99881ee26c6d8
+  md5: 78e8623c1f28ddc113da2d625bb5a8c1
+  depends:
+  - python
+  - ros-humble-launch-ros
+  - ros-humble-launch-testing
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 48990
+  timestamp: 1736210578048
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-testing-ros-0.19.8-np126py311h65a17ee_5.conda
+  sha256: e84503d8a904528a9af12d99ea97bc1d5058e41249853eadfec4e2a226f1182a
+  md5: fa24137f4d8934c4b5e394f4ba9c1283
+  depends:
+  - python
+  - ros-humble-launch-ros
+  - ros-humble-launch-testing
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 48900
+  timestamp: 1736214436825
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-xml-1.0.7-np126py311h2c3b307_7.conda
+  sha256: ad86b74d2750171a3f08d1a8a28799cc33ff68cf48096e74640d7fb519917c1b
+  md5: 700df14b6e285c51ea4a22dc464f8c65
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 25028
+  timestamp: 1736207435414
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-xml-1.0.7-np126py311h65a17ee_5.conda
+  sha256: 98d238924bfdb7b0ba961e1bba9e18c99afe83de884d8881fea8793017574379
+  md5: d69a72253445053b321bdfb8764abcfb
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25008
+  timestamp: 1736207722450
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-launch-yaml-1.0.7-np126py311h2c3b307_7.conda
+  sha256: 005bc5ec38eaf5b0d5b2c23527522e9db94f8dfceeb9f031090e49c2df06b9db
+  md5: df2fca91466c34a67bcd404174edc9d7
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25674
+  timestamp: 1736207429763
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-launch-yaml-1.0.7-np126py311h65a17ee_5.conda
+  sha256: 3763ff7a4ebd4705cc6e1243bbc3a8870c8f7ff723c57c0c00f9d343f92769e6
+  md5: 57fc890c3eb791f5243452bb3121e0a0
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25637
+  timestamp: 1736207709833
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libcurl-vendor-3.1.2-np126py311h2c3b307_7.conda
+  sha256: f9d73d6d18924ec1bd1e125919e7b3cc8e8c9ad24d914966bd1bc7f41dc78a88
+  md5: 41d80515765ff5a0480caa6b02ddbc81
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.11.1,<9.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21749
+  timestamp: 1736207167503
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libcurl-vendor-3.1.2-np126py311h65a17ee_5.conda
+  sha256: 35ea101d9aa49007ec7ef3ceecd358532bd2f68b9b3bd5480553b078cd8ac2a8
+  md5: 7ddb36ecec09b746a04fe97853f5a82b
+  depends:
+  - libcurl
+  - pkg-config
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - libcurl >=8.11.1,<9.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21694
+  timestamp: 1736207473675
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libstatistics-collector-1.3.4-np126py311h2c3b307_7.conda
+  sha256: e96c470373add551ea9673c0260446629f419429fca0ec94309a258ee07b08c6
+  md5: a217de8feb508598958c9baa1586de9e
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rcl
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-statistics-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 53270
+  timestamp: 1736210212443
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libstatistics-collector-1.3.4-np126py311h65a17ee_5.conda
+  sha256: 63551954d130f136ab3a8b0d88bb1f7f2c57f05ce8f384503794d504fa40edaf
+  md5: 47d61b348a65e0240777853b9c388f03
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rcl
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-statistics-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 52727
+  timestamp: 1736213604460
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-libyaml-vendor-1.2.2-np126py311h2c3b307_7.conda
+  sha256: 3846ff5714b983f17bc19db0f7dd54154a902455f6c1d3175d3933db097c4709
+  md5: 871cf3643c829980a4796b1a659b64e9
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml
+  - yaml-cpp
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  license: BSD-3-Clause
+  size: 29150
+  timestamp: 1736208714221
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-libyaml-vendor-1.2.2-np126py311h65a17ee_5.conda
+  sha256: c70b8dd0b54b6821afee1265735859ece4739819ad993663cbb4082d6a42eb4f
+  md5: 2ef192490152d7bebcf68eb62d25a1ab
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml
+  - yaml-cpp
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  license: BSD-3-Clause
+  size: 29170
+  timestamp: 1736209692991
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-lifecycle-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 406f89f6ca43398d965fd134d7443ef462aa96a5c1ff8906bc737f57d04811c5
+  md5: df4a462a044b7be2e2c8ff68b74f5354
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 253186
+  timestamp: 1736212023972
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-lifecycle-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 3ee87711a4f908b4718646b54eec59d017e11678b3d5ea16d117fab0be11dee2
+  md5: 020db72f5b412f9067382ee66069e5a9
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 257890
+  timestamp: 1736215680270
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-lifecycle-msgs-1.2.1-np126py311h2c3b307_7.conda
+  sha256: 03ca4c0d1fc6bb91e07b554d2f38770dbfcbbdf2872942f46a44a79cfee4b300
+  md5: 75e9418889db1f60ae1197e2ef48c033
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 172738
+  timestamp: 1736209124133
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-lifecycle-msgs-1.2.1-np126py311h65a17ee_5.conda
+  sha256: 8c70a6dedce8277dc94bfcfd6e7fd72a1b433f225cc325f71ffef36b6d1e7d84
+  md5: 8e0ed686c488e7c4df64dd7e1dd652bc
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 176711
+  timestamp: 1736211236959
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-logging-demo-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 3a018ef380fce302f025c00dc7547266ed7ef4b75cece3e6188776849bc2f2c8
+  md5: 36873d499c005eb5cb407bd3628762bf
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 185033
+  timestamp: 1736210939010
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-logging-demo-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 9cd7466007c0d6bdf3b5fc7375fe3a720e1d55a76ea59be60417cd100475b94e
+  md5: 3b83afbbc697050e0eaef21f767bbf03
+  depends:
+  - python
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 190901
+  timestamp: 1736215020629
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-map-msgs-2.1.0-np126py311h2c3b307_7.conda
+  sha256: 8b4921aa5ea18a0a52b2b900d5d5d047be56149fa1b9e6fc9d33740cbc1e69d4
+  md5: 79821836c50ed9b479434e9fae91d65a
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 206565
+  timestamp: 1736209658589
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-map-msgs-2.1.0-np126py311h65a17ee_5.conda
+  sha256: 494abe9b268644aaf26f1d5b1e47e2abb5c3caf70984daeb7d59484aed17966b
+  md5: 6b858e3ef9b01f6f3aec823e8cd2e228
+  depends:
+  - python
+  - ros-humble-nav-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 210458
+  timestamp: 1736212380267
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-message-filters-4.3.5-np126py311h2c3b307_7.conda
+  sha256: 3fd35f9f8c8034afd220130f2dcab1b40e51287a6c6979afdb866565ad489754
+  md5: a365a500e291eb81d1f2d601f3aca985
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 71147
+  timestamp: 1736210587945
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-message-filters-4.3.5-np126py311h65a17ee_5.conda
+  sha256: cfc7f14efd88a54de9314157f4489f72b97649a5023dc6537174b33743257652
+  md5: df9af40c61c4fc23dd63365c70e6654c
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclpy
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 71381
+  timestamp: 1736214454223
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-nav-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: f3e50164fcddfe4351700d0e428ddb22f2a0e36d2f3814a934ce015cc29bcd33
+  md5: d0679e17f3ac9c1f60f3cc0d6836d7c3
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 193922
+  timestamp: 1736209566597
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-nav-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: a386e0d6a5350b36fe74990ddd0c3d44952d17b82cb38ad8fc0119a481e7a2d0
+  md5: 12197278546236cb965ab6ab7e9a83f9
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 198694
+  timestamp: 1736212150071
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h2c3b307_7.conda
+  sha256: e997964f67ff46ca7706bc1089356fa53fbd5bf16884276db9e81847d1f1ce61
+  md5: 47a09379786898355d869b4530a39e33
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25359
+  timestamp: 1736208183038
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-orocos-kdl-vendor-0.2.5-np126py311h65a17ee_5.conda
+  sha256: 18351d414e420b33d9b97c11cb443cf133321c90a7dcec5fe93ea695e360086f
+  md5: 94ceb6962cb4aeabf8dff4a8ebe0e1cc
+  depends:
+  - eigen
+  - orocos-kdl
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - orocos-kdl >=1.5.1,<1.6.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25284
+  timestamp: 1736208532691
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-osrf-pycommon-2.1.4-np126py311h2c3b307_7.conda
+  sha256: 863033b9e42aa983c3cba4d9508dee8e067290a43a97dcab4dd4782e5ba2f835
+  md5: 83f4d44a2e14278611c2f27643e71529
+  depends:
+  - importlib-metadata
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 65140
+  timestamp: 1736205371785
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-osrf-pycommon-2.1.4-np126py311h65a17ee_5.conda
+  sha256: 99656c82ed7c432ecc8f955f5ce8c818a58a1d58f43701e21573f806d093cd83
+  md5: 46f6f1cbaa4267e8548f4f83f9be744b
+  depends:
+  - importlib-metadata
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 65092
+  timestamp: 1736205785784
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pcl-conversions-2.4.5-np126py311h2c3b307_7.conda
+  sha256: 2b31fd2ab19a08e72b828dae7e62d730292758a5bd330acee64afffc3abb7ad5
+  md5: bcc4bd2fb0779bfd9a2698bf0aff7462
+  depends:
+  - eigen
+  - libboost-devel
+  - pcl
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pcl-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - vtk-base
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - pcl >=1.14.1,<1.14.2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 58346
+  timestamp: 1736211142855
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pcl-conversions-2.4.5-np126py311h65a17ee_5.conda
+  sha256: 8cf58ba76ff60cf573fae1515f7d35da78038e590aaead196f9d13e59e5df8f5
+  md5: 9467a5f45041a6f87325cf003ec7999c
+  depends:
+  - eigen
+  - libboost-devel
+  - pcl
+  - python
+  - ros-humble-message-filters
+  - ros-humble-pcl-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - vtk-base
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - pcl >=1.14.1,<1.14.2.0a0
+  - vtk-base >=9.3.1,<9.3.2.0a0
+  license: BSD-3-Clause
+  size: 57457
+  timestamp: 1736215030449
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pcl-msgs-1.0.0-np126py311h2c3b307_7.conda
+  sha256: de1feb1dfc991fea7c9cd6ca2758a23512e78927b70bd94d3a7392112e4983dc
+  md5: df5cf945c7abe28113654929ebe97970
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 130557
+  timestamp: 1736209755349
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pcl-msgs-1.0.0-np126py311h65a17ee_5.conda
+  sha256: 99377e8870fa371e3155a157c374e17aab40f613c10f88ce99eeb67594d5e221
+  md5: 7b121b8c8be635121414b63f47ce7fbc
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 133483
+  timestamp: 1736212514105
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pendulum-control-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 35861d44803413096e935541fa75ae3f6a1f9ae668d244737bd09940d1f50ac0
+  md5: 18d1e23451b35faa4a16de140cb17de9
+  depends:
+  - python
+  - ros-humble-pendulum-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rttest
+  - ros-humble-tlsf-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 332058
+  timestamp: 1736211991553
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pendulum-control-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 8751c4dbe7a335a06ad2df57b907ebf352d752f706f9dc2816f83ebbf7e7bc86
+  md5: 3a9e04d6c7847911ff799e54618b4061
+  depends:
+  - python
+  - ros-humble-pendulum-msgs
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rttest
+  - ros-humble-tlsf-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 332455
+  timestamp: 1736215915332
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pendulum-msgs-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 8acef7fab53bcfdbf2496104fbdfaaeb2c7e228514654ef727fc8a41684f1297
+  md5: 872029d9497cf15ec14ab9e3599c13b4
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 86130
+  timestamp: 1736209211251
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pendulum-msgs-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 8011389a38d9f4c31352990e55f406fa4415ef5b10f0beb75545d803e693ab6d
+  md5: f171ba70557229193e58d90fe97541ec
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 89646
+  timestamp: 1736211436273
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pluginlib-5.1.0-np126py311h2c3b307_7.conda
+  sha256: 821465f133cb315c28a4d7a71518ad93996ec315d58879202ddeca42523d02ae
+  md5: 8a0ad18dba8f14429363c82b394ffbe7
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-class-loader
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 39634
+  timestamp: 1736208766346
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pluginlib-5.1.0-np126py311h65a17ee_5.conda
+  sha256: c31b12e4593c14a2dd6084a6e9c7b120401065deb89abf6503ddf0b3c7f538a4
+  md5: 8cf39d493fc7a9a73e14a186c5847a41
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-class-loader
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 39602
+  timestamp: 1736209890760
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-pybind11-vendor-2.4.2-np126py311h2c3b307_7.conda
+  sha256: d7f4c3cebea413e40f40847e9e4f0511ab3058d5137c7f950c16139fb762a60a
+  md5: 326e34fc0e60d584efd941678efbe030
+  depends:
+  - pybind11
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20913
+  timestamp: 1736207166448
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-pybind11-vendor-2.4.2-np126py311h65a17ee_5.conda
+  sha256: dc0082cfd0108919e32748ec2fda39a7d0fc0fc8b603f8da25ffb403b3c501d5
+  md5: f94e4f72754276f8e1d4b3062abd52f6
+  depends:
+  - pybind11
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 20860
+  timestamp: 1736207470931
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-python-cmake-module-0.10.0-np126py311h2c3b307_7.conda
+  sha256: 040ed75c114ffa7178b74812316b1dcfe81e046abbd6afcd87e395fd681f5072
+  md5: 21c05e6bb72f74510b4a74d29d220c46
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 26276
+  timestamp: 1736208166771
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-python-cmake-module-0.10.0-np126py311h65a17ee_5.conda
+  sha256: 41e1aed6746bb0591f3885b0aaf42fb500630869883289be19e556089b05f1f6
+  md5: 378b584679272948606af38ebc14532f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 26313
+  timestamp: 1736208507464
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-python-qt-binding-1.1.2-np126py311h2c3b307_7.conda
+  sha256: caabf4f3a0324566308a70c70e2d662f1a588a227c138bf6602ee22516c4c9ac
+  md5: adeeb09df8b1b8a83b4fd338757b7ae2
+  depends:
+  - pyqt
+  - pyqt-builder
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - pyqt >=5.15.9,<5.16.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 57731
+  timestamp: 1736208187609
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-python-qt-binding-1.1.2-np126py311h65a17ee_5.conda
+  sha256: 3993349be0f663e77e9668a942303b9760d1c65c5d247a56c9efedb7d925662b
+  md5: 8271e164e24eb6e1c9184c2956d96627
+  depends:
+  - pyqt
+  - pyqt-builder
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - pyqt >=5.15.9,<5.16.0a0
+  license: BSD-3-Clause
+  size: 57415
+  timestamp: 1736208542989
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-dotgraph-2.2.3-np126py311h2c3b307_7.conda
+  sha256: 11c2af272f64029deb8ecee8917530fde3ac89c7f733902b780294620ce82dcc
+  md5: db89103629d005daa02949fdaf2fd533
+  depends:
+  - pydot
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 57444
+  timestamp: 1736208500192
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-dotgraph-2.2.3-np126py311h65a17ee_5.conda
+  sha256: 50f23195aead81b322e3cb56838bd0850a49a05774358d3f992d61ddb398caa1
+  md5: 6952ea53b1c7097d1e671ea9f61fc0c7
+  depends:
+  - pydot
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 58315
+  timestamp: 1736209014264
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-2.2.3-np126py311h2c3b307_7.conda
+  sha256: dfd3e789c1eb0f73b9f31fa7664645f391a1c822b05570cafca4e5481aceb6cd
+  md5: de473cc52b5323f5adaadb81b9ee4c3d
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros-humble-tango-icons-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - pyqt >=5.15.9,<5.16.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  license: BSD-3-Clause
+  size: 174622
+  timestamp: 1736208478323
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-2.2.3-np126py311h65a17ee_5.conda
+  sha256: f7227ac4c4d29fc53e394273d1ec7d1e445a6fdac2117eb3daa10e9cb24f1de1
+  md5: c612283ed055c0a608716eff2a40b74c
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros-humble-tango-icons-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - pyqt >=5.15.9,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 174460
+  timestamp: 1736208966325
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-cpp-2.2.3-np126py311h2c3b307_7.conda
+  sha256: c429e009e2839ed79660ede82eae929f3f5dc20832c51135078e858d638d395d
+  md5: e7892b05ebc6b918c12a45e5dd18f93b
+  depends:
+  - pep517
+  - pyqt-builder
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-qt-gui
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 348113
+  timestamp: 1736208824300
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-cpp-2.2.3-np126py311h65a17ee_5.conda
+  sha256: 81627bf42e95b42605c87b8ef871b589c549d0d08ff0349a2eba01990b7d7ed3
+  md5: e7037ce7262feb2683dc6f3ca84d6255
+  depends:
+  - pep517
+  - pyqt-builder
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-qt-gui
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 343297
+  timestamp: 1736210258877
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-qt-gui-py-common-2.2.3-np126py311h2c3b307_7.conda
+  sha256: 9c8465ae2eb51d3140be6c6636a34100d9cfe8e3245703cb53250bb554eced85
+  md5: 02811a202e80a26a6422a68deec2abdf
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 37542
+  timestamp: 1736208495501
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-qt-gui-py-common-2.2.3-np126py311h65a17ee_5.conda
+  sha256: fb94d0fe3c4ead29e5b9d3a08fbed2af154e3af3f08075faf96cad68fda039bc
+  md5: 0df13d024cd2bd8be53a014747106380
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 37633
+  timestamp: 1736209002696
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-quality-of-service-demo-cpp-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 7e79380dfe027690effa0fac75abf1b2d0e15b5454b2e8bf2cfd650f095d0286
+  md5: 1b27eb0d8b9148e757ab81d4e5fd3458
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 604900
+  timestamp: 1736210578135
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-quality-of-service-demo-cpp-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 45fbb3e25a83e42a5833b9bfe40887307338661ed2684c0af895f3d588b3ccf5
+  md5: e48739e52e5aeafd727f3d80bcfc0efc
+  depends:
+  - python
+  - ros-humble-example-interfaces
+  - ros-humble-launch-ros
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 586058
+  timestamp: 1736214618145
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-quality-of-service-demo-py-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 8afeba4628faf9eefcf95ac794b8da2ad21fcd29849c8f2902c2ecd544e5fd52
+  md5: d955d74b2774533ba0094262c2ee227a
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 33670
+  timestamp: 1736210426251
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-quality-of-service-demo-py-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 04ddb0e739ef434c74fbd30fab83439eb7cd0f752ef3ae5136af1e0727495d03
+  md5: 980fd22ac6bca681cc091aa1be7ba2b0
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 33742
+  timestamp: 1736214201564
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-5.3.9-np126py311h2c3b307_7.conda
+  sha256: 10ae7ba2e260747d811a79f9bac167d78b906180b4345dfe4ec34405eaa4eb6c
+  md5: a13422c002b683a1ff44d8ebd63d45b3
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcl-logging-spdlog
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 173948
+  timestamp: 1736209862377
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-5.3.9-np126py311h65a17ee_5.conda
+  sha256: 7f6ca37bce64a0452d7176120cbbb1eb58f95d2d5871e05e18fb303c3071e563
+  md5: 4db4f2bd4d642b7ae1988c0bc3c55237
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcl-logging-spdlog
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 179364
+  timestamp: 1736213010978
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-action-5.3.9-np126py311h2c3b307_7.conda
+  sha256: 1d9c675c6c935f1accde23409dd94692da59aa0c7f39c93bf55b1ec9a5f26b9a
+  md5: f735d3c83c48ffb6fbfd2a989a9d2325
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-rcl
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 75899
+  timestamp: 1736210205736
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-action-5.3.9-np126py311h65a17ee_5.conda
+  sha256: 818a76bf2cba2a3f0f552dc975ebcb8cc63f1cd77796bd9c09ef5d58528e424b
+  md5: 2ac25f1993fc9f3058db83981585ac0c
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-rcl
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 76509
+  timestamp: 1736213586461
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-interfaces-1.2.1-np126py311h2c3b307_7.conda
+  sha256: f7ee5507ab4d45876a5aa65cb1dd06b704556dbcae158ec66571032488e94566
+  md5: 96f7f4a23f6f1fdfa3716244d2c6a003
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 336972
+  timestamp: 1736209247319
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-interfaces-1.2.1-np126py311h65a17ee_5.conda
+  sha256: de35fad763037a4d17439734468ebcffbbc6a6b90c1dcc4abb5d94ea276db8b0
+  md5: 5045852bc078b32d6be4fe6241d5275a
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 341063
+  timestamp: 1736211531043
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-lifecycle-5.3.9-np126py311h2c3b307_7.conda
+  sha256: 0442516d972104da2fca112d46cf52d5c1c8d3c1d786a45e1b23205a796a851f
+  md5: 093a73d1b590288701b83b85acd5c6da
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rcl
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 54161
+  timestamp: 1736210192927
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-lifecycle-5.3.9-np126py311h65a17ee_5.conda
+  sha256: 9c142b9257c9295337e91bab3b12882f468ba0b5d8815a8d6df0a5f778b275e4
+  md5: 9e6aa9b17e96a0f54fc9fd64053ffadd
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rcl
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 55000
+  timestamp: 1736213561175
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-interface-2.3.1-np126py311h2c3b307_7.conda
+  sha256: b0d434c043b68210f7c72b498a7a8ba8803b43fa007a7585803e83eeeeef14eb
+  md5: 54b78e1ff83cc6f0f6612f23ed5dcaf5
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 33395
+  timestamp: 1736208685007
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-logging-interface-2.3.1-np126py311h65a17ee_5.conda
+  sha256: 8c1bc7a20037f7f3135c0dae463af580f2fdd13ec377c5484f92d25cd710760a
+  md5: 7c601b789832af24b2e863cf67b16ff0
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 33825
+  timestamp: 1736209637439
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h6a008e1_7.conda
+  sha256: 6933b2931b5a38f5e589352868e98f1598cffa12fb0f9442c58528b6cd24319f
+  md5: a9866d37cdb01c4abef05ab3fe905f81
+  depends:
+  - python
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-spdlog-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - spdlog
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 40461
+  timestamp: 1736208760034
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-logging-spdlog-2.3.1-np126py311h1db7994_5.conda
+  sha256: b779e2d03305b8231ae7d17671463993de9a110b75e74293e661903e15c21833
+  md5: 408de23fdbb0a1dfd6ab77cb92a753b7
+  depends:
+  - python
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-spdlog-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - spdlog
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 41545
+  timestamp: 1736209873313
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h2c3b307_7.conda
+  sha256: 6256cc8c439c4fbb71a96c954e97ab01b17dde7a9445cee784097f0d87ad49fb
+  md5: e9af8ba6637a6d1260e0c042ba3f675a
+  depends:
+  - python
+  - ros-humble-libyaml-vendor
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml
+  - yaml-cpp
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 49219
+  timestamp: 1736208753802
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcl-yaml-param-parser-5.3.9-np126py311h65a17ee_5.conda
+  sha256: c69241dfec8b7bfa7fbf0f85308f65f0aec7c6a30deb9aed842f187d988e3163
+  md5: 027a09a13cafc8c2b7a6be07d6420470
+  depends:
+  - python
+  - ros-humble-libyaml-vendor
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml
+  - yaml-cpp
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - yaml >=0.2.5,<0.3.0a0
+  license: BSD-3-Clause
+  size: 50917
+  timestamp: 1736209854305
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-16.0.11-np126py311h2c3b307_7.conda
+  sha256: e89abf81843882a61bb12febcc2011071dd7484808939b6a906dc1172f2ac9ec
+  md5: bdafe149f67cb95d73c343c58b13420d
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-builtin-interfaces
+  - ros-humble-libstatistics-collector
+  - ros-humble-rcl
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosgraph-msgs
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-statistics-msgs
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 879484
+  timestamp: 1736210313183
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-16.0.11-np126py311h65a17ee_5.conda
+  sha256: 2fa5b2006961388564c75326c3dc08ce034f865a4a9efdb7c8e2b967bcd54f27
+  md5: e3939a34d0a83c4325a062f333608f96
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-builtin-interfaces
+  - ros-humble-libstatistics-collector
+  - ros-humble-rcl
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosgraph-msgs
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-statistics-msgs
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 848607
+  timestamp: 1736213873480
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-action-16.0.11-np126py311h2c3b307_7.conda
+  sha256: ae76ddfe66ceed018f32162b3654b9f0744f9ab3418d73052419268590986f3a
+  md5: faf068b4ec298d2edc237eec1fb0058b
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ament-cmake
+  - ros-humble-rcl-action
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 112375
+  timestamp: 1736210464521
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-action-16.0.11-np126py311h65a17ee_5.conda
+  sha256: 95599b67bf3f8041b5a3380940f9818d79c4e29245bfe5ea8e826764a2f8ce06
+  md5: a456e4be254f1465d5fc32bc0b384f06
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ament-cmake
+  - ros-humble-rcl-action
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 114809
+  timestamp: 1736214173970
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-components-16.0.11-np126py311h2c3b307_7.conda
+  sha256: 4996d9feb2950e045e62c5682f8a7a7518a2fb6926d2dec57ccb371f0e4b8a5d
+  md5: 21a7182fdfca3243ff32649e2a5c2fd8
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-class-loader
+  - ros-humble-composition-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 133226
+  timestamp: 1736210449253
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-components-16.0.11-np126py311h65a17ee_5.conda
+  sha256: 75cc152baa570ee86783ce0167c9846baeb55b904631434df991cd778b7311bc
+  md5: 26967e6e9f5657dda6a430d2d6b78501
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-class-loader
+  - ros-humble-composition-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 134891
+  timestamp: 1736214137867
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h2c3b307_7.conda
+  sha256: 977702f2e3c4cccd71a3dba3071f47a55a42997ca30ae5d2d3b39f32002cb4d9
+  md5: 5756a6d5aa6a219e664706a6e2be371f
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 124187
+  timestamp: 1736210426425
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclcpp-lifecycle-16.0.11-np126py311h65a17ee_5.conda
+  sha256: eac050bcc0f561213e59c1829ac7311eedcefc86eb5b0fd34c44048087e4ce22
+  md5: 341a3fcd5798763c9c05c762416f5c56
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 123232
+  timestamp: 1736214084251
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rclpy-3.3.15-np126py311h2c3b307_7.conda
+  sha256: e4aacf4314377feddd6716374afd67754887f6939b31a1a74e602c38a0cb6f14
+  md5: 1f1c532e2fa65c5e7600a61c1b75dee3
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rcl
+  - ros-humble-rcl-action
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosgraph-msgs
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rpyutils
+  - ros-humble-unique-identifier-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 580154
+  timestamp: 1736210240299
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rclpy-3.3.15-np126py311h65a17ee_5.conda
+  sha256: 2616f87d5abb5d34c862c2b25fe7aec4cf72b54a5f19ae18ced239d948da79e7
+  md5: edb5644e5a3958d9fdd8b6374a8a5a52
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-builtin-interfaces
+  - ros-humble-rcl
+  - ros-humble-rcl-action
+  - ros-humble-rcl-interfaces
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rcl-logging-interface
+  - ros-humble-rcl-yaml-param-parser
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosgraph-msgs
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rpyutils
+  - ros-humble-unique-identifier-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 544026
+  timestamp: 1736213751503
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcpputils-2.4.4-np126py311h2c3b307_7.conda
+  sha256: ea7cb5abd4848b5e572bbc9d2657abc6754be95851ba55a99fa5b488e1e7e689
+  md5: daf7ab15c9eea467521433f40260221b
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 77633
+  timestamp: 1736208642128
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcpputils-2.4.4-np126py311h65a17ee_5.conda
+  sha256: 4c92fed20478e3393cddd26dbec3ecb3f7cc1561fe8b9db2d31d7455a63ee613
+  md5: f4448dded95cd0908288e9dc891bd4d7
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 78076
+  timestamp: 1736209470036
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rcutils-5.1.6-np126py311h2c3b307_7.conda
+  sha256: 57d309d38369ed7e7b6d3d204da7efff54b97a326386a112b4a32a765a74efcb
+  md5: ea3588b5f23a59c1e4d30ad0cb93cb09
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 115567
+  timestamp: 1736208525657
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rcutils-5.1.6-np126py311h65a17ee_5.conda
+  sha256: c4ceca55bf99d05d79f997e02efe50f5383e283fa9a5c60881cc15d2de8471a9
+  md5: 0edba5287d3b7123bc5485df3bddb7ba
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 120056
+  timestamp: 1736209171510
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-resource-retriever-3.1.2-np126py311h2c3b307_7.conda
+  sha256: 1c09c47ff836f88bb5b16d050987b2dfd7f0b0449d5cf6f1e4d5e1a9ccf85cb7
+  md5: 5d393b257fd1d2be98d0949d7e6d480b
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-libcurl-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 42858
+  timestamp: 1736208466401
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-resource-retriever-3.1.2-np126py311h65a17ee_5.conda
+  sha256: 1ee654e3b1a294065ae2af67181a36dc6806dcb91bc87cdeab14a97fabd1d4c6
+  md5: d12eb4a0141b93a5413d0768361ff553
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-libcurl-vendor
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 43617
+  timestamp: 1736208946572
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-6.1.2-np126py311h2c3b307_7.conda
+  sha256: b52718f33a8153f3b42703f082ddd4be86aa651fb5e451b1cdb3c0173a0194c9
+  md5: c39366fc5b2a6f2add7877255b717855
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 89807
+  timestamp: 1736208702493
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-6.1.2-np126py311h65a17ee_5.conda
+  sha256: 0fc16c93e9ae9d53b36df0f4db043337a68138524590c0a4f3f8be25b4fd82d5
+  md5: 79aec73ee387680582adecf66e1e2b01
+  depends:
+  - python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 91290
+  timestamp: 1736209666782
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-0.11.3-np126py311h2c3b307_7.conda
+  sha256: ae04af290fef3c62a8f1b21fdaeb05e082ebb817c8d3fecca0b81c9b9aa57795
+  md5: c5a7885985da107e73ef7d888bd7f7ad
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rmw-connextdds-common
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 28811
+  timestamp: 1736209365710
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-0.11.3-np126py311h65a17ee_5.conda
+  sha256: 99f576687500760f1036849ba1fb07bbdf6a37e9483e12a29e72d6498bed883f
+  md5: 91e2d9938ba951623553892773b885f3
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rmw-connextdds-common
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 28744
+  timestamp: 1736211796254
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h2c3b307_7.conda
+  sha256: 666b87de857aed1afb0479baae9017c089b80e047fd05520bd9d8bc19d076cd1
+  md5: 5bf8c723bf885e2e2cc2968628a2a5be
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-rti-connext-dds-cmake-module
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 50348
+  timestamp: 1736209225260
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-connextdds-common-0.11.3-np126py311h65a17ee_5.conda
+  sha256: 77b3a8d3a8f4c0370ac26426401e6bfc592793b4dcad451d08161b5092fada84
+  md5: eee498ff1066a187da722e2482afa4af
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-rti-connext-dds-cmake-module
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 50334
+  timestamp: 1736211477948
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h2c3b307_7.conda
+  sha256: 612debb54800d9726f553e9cb73da10185b471cf6124482095c9126c55fa8337
+  md5: 9aa1791c2bc46e4b260d0b68a25743d0
+  depends:
+  - python
+  - ros-humble-cyclonedds
+  - ros-humble-iceoryx-binding-c
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 255856
+  timestamp: 1736209230301
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-cyclonedds-cpp-1.3.4-np126py311h65a17ee_5.conda
+  sha256: bfb803b2b5795e4121bfecc49adbdd2b2b98417a781785159aa82ae903c3417e
+  md5: 561df705e14be431625abee37ad85c81
+  depends:
+  - python
+  - ros-humble-cyclonedds
+  - ros-humble-iceoryx-binding-c
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 255599
+  timestamp: 1736211488998
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-dds-common-1.6.0-np126py311h2c3b307_7.conda
+  sha256: 08d5319babf86b0108e5ed517c6fda9accd151ec1236b98b2519629e8d7188c4
+  md5: 33ec99fc1512751feb3001c085a7a170
+  depends:
+  - python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 146726
+  timestamp: 1736209110541
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-dds-common-1.6.0-np126py311h65a17ee_5.conda
+  sha256: e69b512ad8dbebdbba78f0291f81e224b3d5c3925703f5df68a9a2eb714de6d6
+  md5: a1e8fdb9229488cc3f041bcc36b09f47
+  depends:
+  - python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 148659
+  timestamp: 1736211209092
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h2c3b307_7.conda
+  sha256: bd3f3b45a201ba01a88748563554c1a89a0280847e302f4e8c0cf88eab2e9105
+  md5: 6b9d566d25ca39278dbb0915a24c871e
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-rmw-fastrtps-shared-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 141654
+  timestamp: 1736209532247
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-cpp-6.2.7-np126py311h65a17ee_5.conda
+  sha256: 64ba123738e194956c5bc5b99f0789968b4e795066469a9ad8ab2f784b432fc5
+  md5: 4d43002dcbf51b21bec9cf2579cafafd
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-rmw-fastrtps-shared-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 142980
+  timestamp: 1736212075890
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h2c3b307_7.conda
+  sha256: c51726c6a11aeca2a02cf2ce849cb9a3961dc6e3ad99c6b285097b76d6910e7a
+  md5: eaff8fb243ea337bc091e058e6be6c42
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-rmw-fastrtps-shared-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 183963
+  timestamp: 1736209495606
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-dynamic-cpp-6.2.7-np126py311h65a17ee_5.conda
+  sha256: 15d73112ef56b24df256f593d69b4156e795be0ab89fab0a126824e65a55e9d6
+  md5: 48b86987be740958c4a6db13ae8a2017
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-rmw-fastrtps-shared-cpp
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 177753
+  timestamp: 1736212036326
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h2c3b307_7.conda
+  sha256: a4cf83a15a7046a4aaf8e71fa121323990e1d1fcc3d9673107a62e6afaca61e1
+  md5: 482b56dcd7e9c65df65d8e5030d8ef49
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 211721
+  timestamp: 1736209193472
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-fastrtps-shared-cpp-6.2.7-np126py311h65a17ee_5.conda
+  sha256: 3102351ddf8a330ddc6f5173a9e56680dc99573665715cb711b6e3c7e0f92bf8
+  md5: 024f6ba624f681f0f1db7fcb7d0dc95b
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-dds-common
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-tracetools
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 199868
+  timestamp: 1736211441897
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-2.8.4-np126py311h2c3b307_7.conda
+  sha256: 552b10a46f29b020745a6fdc90d08c4fefc8515644f921b36b9d936c3e450c55
+  md5: 90b5c1f0ad014f6bea537bd10c8d1bd3
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw-connextdds
+  - ros-humble-rmw-cyclonedds-cpp
+  - ros-humble-rmw-fastrtps-cpp
+  - ros-humble-rmw-fastrtps-dynamic-cpp
+  - ros-humble-rmw-implementation-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 50584
+  timestamp: 1736209657772
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-2.8.4-np126py311h65a17ee_5.conda
+  sha256: 0fabd4e7949e158d32865992882fe70661dbe1a4d846ce255069c08862c52d15
+  md5: 0bbff7133b4efbe9cba0ead3c7c55024
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw-connextdds
+  - ros-humble-rmw-cyclonedds-cpp
+  - ros-humble-rmw-fastrtps-cpp
+  - ros-humble-rmw-fastrtps-dynamic-cpp
+  - ros-humble-rmw-implementation-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 52344
+  timestamp: 1736212381007
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h2c3b307_7.conda
+  sha256: 9ece7a203f7e44255dfdf812e477a4fed3615f1dabfad00b6f80f09a9043b82b
+  md5: e28e1792d5a96e03a9aa3bf27601cb76
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27146
+  timestamp: 1736208432657
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rmw-implementation-cmake-6.1.2-np126py311h65a17ee_5.conda
+  sha256: f1067c8de42d6525624f5fe84de93d069c1152b76ed689b502e1efb04fd7eac0
+  md5: 5f34395b436e23126b9034845a4b212f
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27218
+  timestamp: 1736208793404
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-robot-state-publisher-3.0.3-np126py311h2c3b307_7.conda
+  sha256: a04e232d30a7fac7146a7a36776dd61fb6176c39193699f1fe4409276529e455
+  md5: 64734374ee4c9bf82d8fd78dffe7d8f2
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-kdl-parser
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 254123
+  timestamp: 1736211799236
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-robot-state-publisher-3.0.3-np126py311h65a17ee_5.conda
+  sha256: 65b5c8b3d9c7853dffd109ad6c79eff60f783026dfe77423fe7b48174b302e2f
+  md5: 746d7b5c6b5068fffa56c1ef0c857fec
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-kdl-parser
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 252475
+  timestamp: 1736215324517
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-base-0.10.0-np126py311h2c3b307_7.conda
+  sha256: fb396d7bc78951c1828f2b68c82c600d43c116ddce42a462eb6f7af31524e16b
+  md5: 82b6cb45214797a894f0276266abb79d
+  depends:
+  - python
+  - ros-humble-geometry2
+  - ros-humble-kdl-parser
+  - ros-humble-robot-state-publisher
+  - ros-humble-ros-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20781
+  timestamp: 1736214867192
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-base-0.10.0-np126py311h65a17ee_5.conda
+  sha256: 20b7810218d4aa8b79668a0de0ecb32b7f767067656becb499d9527d989518c1
+  md5: 6dc6536e2aaa1db336e02a81bde0fb64
+  depends:
+  - python
+  - ros-humble-geometry2
+  - ros-humble-kdl-parser
+  - ros-humble-robot-state-publisher
+  - ros-humble-ros-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2
+  - ros-humble-urdf
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20743
+  timestamp: 1736219830124
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-core-0.10.0-np126py311h2c3b307_7.conda
+  sha256: de6f090a8c8b48642c74530f84c5e774c9bf7b2a04a8518c878c6a90be25d37c
+  md5: d3a99c7af96484b7a63b2240f83ada73
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-auto
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-pytest
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-ament-lint-auto
+  - ros-humble-ament-lint-common
+  - ros-humble-class-loader
+  - ros-humble-common-interfaces
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-launch-testing
+  - ros-humble-launch-testing-ament-cmake
+  - ros-humble-launch-testing-ros
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-pluginlib
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rclpy
+  - ros-humble-ros-environment
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli-common-extensions
+  - ros-humble-ros2launch
+  - ros-humble-rosidl-default-generators
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sros2
+  - ros-humble-sros2-cmake
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21492
+  timestamp: 1736212873563
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-core-0.10.0-np126py311h65a17ee_5.conda
+  sha256: eef2ed6fd110235742f5e4d8cc04814963bf97a0ab7a42688fa9739ce5dd48f0
+  md5: f87c5eaf8d861c115953bc537f8a2787
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-cmake-auto
+  - ros-humble-ament-cmake-gmock
+  - ros-humble-ament-cmake-gtest
+  - ros-humble-ament-cmake-pytest
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-cpp
+  - ros-humble-ament-index-python
+  - ros-humble-ament-lint-auto
+  - ros-humble-ament-lint-common
+  - ros-humble-class-loader
+  - ros-humble-common-interfaces
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-launch-testing
+  - ros-humble-launch-testing-ament-cmake
+  - ros-humble-launch-testing-ros
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-pluginlib
+  - ros-humble-rcl-lifecycle
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-lifecycle
+  - ros-humble-rclpy
+  - ros-humble-ros-environment
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli-common-extensions
+  - ros-humble-ros2launch
+  - ros-humble-rosidl-default-generators
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sros2
+  - ros-humble-sros2-cmake
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21441
+  timestamp: 1736216833394
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-environment-3.2.2-np126py311h2c3b307_7.conda
+  sha256: a3ba1ae288be4d8981a33622c7ce7934f4dbdd93a9faf65dd89f3dba9f0ff735
+  md5: 2827f64436920c02631b8b3077433824
+  depends:
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 19829
+  timestamp: 1736205330450
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-environment-3.2.2-np126py311h65a17ee_5.conda
+  sha256: 5535063811efbe1746e4faa266dfddcf889e40f554f55bae6a9e85df63ecb48e
+  md5: 1c0866921f42d2e1790b4415269de652
+  depends:
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 19801
+  timestamp: 1736205635723
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros-workspace-1.0.2-np126py311h2c3b307_9.conda
+  sha256: 8bddb8cdc2def1c3ad6b1140e9c243572ea884934391f861ad53589e0aa897f5
+  md5: 7f9633981b7c3251d8ee1732a3694909
+  depends:
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 35415
+  timestamp: 1736974255672
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros-workspace-1.0.2-np126py311h65a17ee_9.conda
+  sha256: 19264cb86b32554d560df50011d67993378794f63b53de43da7825bae3c4b1c7
+  md5: 69118b429b662aa041b0c7c6b24fda63
+  depends:
+  - python
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 35395
+  timestamp: 1736974402234
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2action-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 702442284cd1655343719759a830695f1e704ba71a399ec1dbf647d9b8beabd6
+  md5: d414813c0c262a3c295ec9b5af072db6
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 42554
+  timestamp: 1736211176837
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2action-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 5069f49583a4ed8548eb2987f65256d05977eac7c7cd7b5166bd0e949f7b04bf
+  md5: 6a8ef612dbfe6e07510f6bf428f6ad35
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 42442
+  timestamp: 1736215098065
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2bag-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 25a5a6c00d613418812736ef3f92c1dbb10d316b0a239bd29220a96693bb581f
+  md5: ab4c4a6e4f44a36d03707d5e835febd6
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosbag2-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 52778
+  timestamp: 1736214263452
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2bag-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 9b2f9bce5d13febd7e0705ef0f1d619dc26731f635b0efda3bd83ae497be3580
+  md5: 9055947278343df429e8dc2ed4abd088
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosbag2-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 52702
+  timestamp: 1736218604550
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-0.18.11-np126py311hdfa6bdf_9.conda
+  sha256: f227cf111d7180a8386b0f8b0f9ba336112b1a71f78a2cab64b202f675c5368c
+  md5: eb75b044553d1f95ba04c7ffaa6e5f38
+  depends:
+  - argcomplete
+  - importlib-metadata
+  - netifaces
+  - packaging
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 74347
+  timestamp: 1744199512016
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2cli-0.18.11-np126py311hdeb5fcf_9.conda
+  sha256: 2d49d055c2cdaf3dec7622cb7a370734f201a770a03fc69807d8f9c4cc4b4deb
+  md5: 54d6c59bb2b183aafb5884f9c881f8a3
+  depends:
+  - argcomplete
+  - importlib-metadata
+  - netifaces
+  - packaging
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 74140
+  timestamp: 1744199799580
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h2c3b307_7.conda
+  sha256: dfc33f265b04a79b019f1182b373959b407f64e407a06dfa6afe4ab9f4a971e3
+  md5: 3c0e29c762ae982c5243b74bc57ca544
+  depends:
+  - python
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-ros-workspace
+  - ros-humble-ros2action
+  - ros-humble-ros2cli
+  - ros-humble-ros2component
+  - ros-humble-ros2doctor
+  - ros-humble-ros2interface
+  - ros-humble-ros2launch
+  - ros-humble-ros2lifecycle
+  - ros-humble-ros2multicast
+  - ros-humble-ros2node
+  - ros-humble-ros2param
+  - ros-humble-ros2pkg
+  - ros-humble-ros2run
+  - ros-humble-ros2service
+  - ros-humble-ros2topic
+  - ros-humble-sros2
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 24508
+  timestamp: 1736212526034
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2cli-common-extensions-0.1.1-np126py311h65a17ee_5.conda
+  sha256: 0665d1a266f43472cf4de0c2106228750fe8ec98df5bf8379a701d638a9e0a9d
+  md5: 474612b70e8ea8b90fa5652314c3f8ce
+  depends:
+  - python
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-ros-workspace
+  - ros-humble-ros2action
+  - ros-humble-ros2cli
+  - ros-humble-ros2component
+  - ros-humble-ros2doctor
+  - ros-humble-ros2interface
+  - ros-humble-ros2launch
+  - ros-humble-ros2lifecycle
+  - ros-humble-ros2multicast
+  - ros-humble-ros2node
+  - ros-humble-ros2param
+  - ros-humble-ros2pkg
+  - ros-humble-ros2run
+  - ros-humble-ros2service
+  - ros-humble-ros2topic
+  - ros-humble-sros2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 24494
+  timestamp: 1736216396419
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2component-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 5c9af67fa1a3ddb8d0837065cab5698addc143c33e4b66a05723e19cc3456dbd
+  md5: 75140c0d0a706c7a66609e6a0fefcdd3
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-composition-interfaces
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp-components
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2param
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 37708
+  timestamp: 1736212002425
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2component-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 1ab9d000aa75fae43576a3e293edf66e56b0c0306f8bc83a4db3b45c46d3ecf3
+  md5: 7ec4775766d0fd7ed0ef32705faa3fd8
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-composition-interfaces
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp-components
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2param
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 37765
+  timestamp: 1736215686090
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2doctor-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 6483f68e9ca4f7a67184857d097e1d43a6ae6fd2a88a6f37d1c2ceaf50b2c1fe
+  md5: 22e7ebd646f1b1ea4306b1a2e41c4574
+  depends:
+  - catkin_pkg
+  - importlib-metadata
+  - psutil
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-environment
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - rosdistro
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 64878
+  timestamp: 1736211170797
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2doctor-0.18.11-np126py311h65a17ee_5.conda
+  sha256: c548a56bae5457a414c663e20a8acd1b3c9787becd7ea7bc556e25261e005cff
+  md5: 5859b862580c536473e9748a05d60b73
+  depends:
+  - catkin_pkg
+  - importlib-metadata
+  - psutil
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-environment
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - rosdistro
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 64826
+  timestamp: 1736215086057
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2interface-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 52a9c8c66a8f029f48c55ecd398973ff04ae24099bef99e69e9dc921662f04d7
+  md5: 4ef5044395a11983b08931440264b9e6
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 43116
+  timestamp: 1736211162206
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2interface-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 7c756353a8152391c5e41236bce4771f7d507d4a1f5030aa5497626b9460bd43
+  md5: 44a9f01fff02abac559cccd287484a62
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 42985
+  timestamp: 1736215069427
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2launch-0.19.8-np126py311h2c3b307_7.conda
+  sha256: 172c0b28223c891cc948eca3a739bbe34b952bdd27c47525681863ee69331bbc
+  md5: 956d6e255ecbb7d62c2248942ca669c9
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 43405
+  timestamp: 1736211633778
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2launch-0.19.8-np126py311h65a17ee_5.conda
+  sha256: 75d5e7d000252f2e4eb02ecab0ea95c7ea0bbc989189854cfe58f43d0052d60b
+  md5: e65a86ba37e6b9f0f897bc3c5ed52c68
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-launch-xml
+  - ros-humble-launch-yaml
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 43226
+  timestamp: 1736215367544
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2lifecycle-0.18.11-np126py311h2c3b307_7.conda
+  sha256: f38e3b1dcbf679580b9fab3b0fbd71c0e9300a214750bc580488eb327eff42d6
+  md5: f6a700d141a6fcf2a28b254f3b2cad93
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2service
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 42478
+  timestamp: 1736211657900
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2lifecycle-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 8aa8dcedb96afc7a4d7ae6bff7b8f5d028c89c1a506dd9ce915d033ec06a358b
+  md5: 64fa150780a3f6ae7060fe42b79e0136
+  depends:
+  - python
+  - ros-humble-lifecycle-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2service
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 42402
+  timestamp: 1736215371887
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2multicast-0.18.11-np126py311h2c3b307_7.conda
+  sha256: cbf0c41a3d84bc28b75d6ef933ca102a2774ac5a367045ba18a72b694fcb07b6
+  md5: a920f865932d4b2012e9223a6e8323a9
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 34729
+  timestamp: 1736210885421
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2multicast-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 7a3ee7f4643972eea42f6a91f38ef176e985990a6094f8c83cd851af5f6e1ae2
+  md5: a2e772799b0b9f2e21c7323059934c1f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 34681
+  timestamp: 1736214773636
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2node-0.18.11-np126py311h2c3b307_7.conda
+  sha256: ebd6a58dc944763ce1a5a5dc2f13e61fc527583fe684877d2db5dd8b3939a25f
+  md5: 3c309f9388e247f1eda5fe60669e1e51
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 39755
+  timestamp: 1736211141044
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2node-0.18.11-np126py311h65a17ee_5.conda
+  sha256: d97dcbe43e1184fbce0a22d63caeb7b3c2a429d3a42f1e1e6614e900fc69b759
+  md5: 33488a8186e2e6bd0d269adbe201f717
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 39645
+  timestamp: 1736215018535
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2param-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 8627e009f9489542b994b7a7b96262462772b49d2a99af694bb080b1b8a0d54c
+  md5: f10244623c6974fe9057b55b12d8eeb3
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2service
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 51586
+  timestamp: 1736211662087
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2param-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 93a4713e93821039b7b3c85049604c139d3d8d37859cf5d4eb33d0189015261f
+  md5: 48f89c443fa5a52ce24ec119a953ef87
+  depends:
+  - python
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2node
+  - ros-humble-ros2service
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 51582
+  timestamp: 1736215408211
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2pkg-0.18.11-np126py311h2c3b307_7.conda
+  sha256: d43bfa5c332fa6a0e3f58565791e510c90c5dce84df3d0018b30836eef04ce2b
+  md5: ee6870f4f5d70f691435c2d43f71c889
+  depends:
+  - catkin_pkg
+  - empy
+  - importlib_resources
+  - python
+  - ros-humble-ament-copyright
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 55105
+  timestamp: 1736210940379
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2pkg-0.18.11-np126py311h65a17ee_5.conda
+  sha256: ba4a63deadc07233ad9198e7f1a2a6a293167bba6365a2b94354e3087a5572e8
+  md5: a52f95c4ec030bdc989c1129430d3315
+  depends:
+  - catkin_pkg
+  - empy
+  - importlib_resources
+  - python
+  - ros-humble-ament-copyright
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 55094
+  timestamp: 1736214983670
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2run-0.18.11-np126py311h2c3b307_7.conda
+  sha256: 24b87ef1beaca243be01db42b96f8015f31055b825d356da786c439f755d6e92
+  md5: a74c92bd393eca91a6217da5443a45a5
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 34616
+  timestamp: 1736211654884
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2run-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 8c91594c701812f8b3c91ce624204e62a418eecfe18b28e5460a5b9114862294
+  md5: e777c7b460e4036f0267866ca456f792
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-ros2pkg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 34532
+  timestamp: 1736215393379
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2service-0.18.11-np126py311h2c3b307_7.conda
+  sha256: a5273739c31cb1e5eaf01cfa2554d6120fb4a8dd4615d892d219dcc28c92a74f
+  md5: fbac42edc31e04c92ef3627433941c4c
+  depends:
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 41414
+  timestamp: 1736211135341
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2service-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 875589a229b537d5cfc9760a5b2abf954ccb51f4f5384ca7421883f8c5aa4926
+  md5: 65a51a30d843ba69f7120fd3cafda3ca
+  depends:
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 41294
+  timestamp: 1736215005633
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-ros2topic-0.18.11-np126py311h2c3b307_7.conda
+  sha256: a4366b135a7b816df5c9420365d306a7b6ae670d9aeef28bc29be62d69058be2
+  md5: e25c14d5c059c13795f49db31f9ba909
+  depends:
+  - numpy
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 71809
+  timestamp: 1736210940846
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-ros2topic-0.18.11-np126py311h65a17ee_5.conda
+  sha256: 1b4bddce5e795bc85d78294d7af51cd66388ecdf335952427c1b3feeb943800c
+  md5: ae9c705ede3e0d9f0c492cc061304e97
+  depends:
+  - numpy
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-rosidl-runtime-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 71674
+  timestamp: 1736214983699
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 95be952c1860a70310af699d06e3b23b0d8f5e518de22a0c5d710da53eb6d60d
+  md5: 5c1ca0b5498829a6cc63d02fedcd3d87
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2bag
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-compression-zstd
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-py
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosbag2-storage-default-plugins
+  - ros-humble-rosbag2-transport
+  - ros-humble-shared-queues-vendor
+  - ros-humble-sqlite3-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 29880
+  timestamp: 1736214742366
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-0.15.13-np126py311h65a17ee_5.conda
+  sha256: dec575e92a6e3a2fa24af9c731e4abe2ce57f65c242015390f5a6e3cd505282a
+  md5: 4e9eeba7f07a5c4cacfd601fe6708e16
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2bag
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-compression-zstd
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-py
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosbag2-storage-default-plugins
+  - ros-humble-rosbag2-transport
+  - ros-humble-shared-queues-vendor
+  - ros-humble-sqlite3-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 29755
+  timestamp: 1736219525901
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 1e4c792af5fa807724096eb1ebb65050c71e82570f4ac405fece3a6a6660a35f
+  md5: 0c06ec134116c3729eae744a8ba4b268
+  depends:
+  - python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-storage
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 195376
+  timestamp: 1736212017445
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-compression-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 45991caa40d4ebc6ee0dcb61c2206c4e4a295a9a40dd8e0f5bc0e74c6ae905ab
+  md5: 15b7a875dbdac483a3abaa86ca8abc45
+  depends:
+  - python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-storage
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 191779
+  timestamp: 1736215733365
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h2c3b307_7.conda
+  sha256: a65af90d5887271ec4f57465ad4c7ad0fbcff750ecdbf70f4e0a73a27472ade2
+  md5: f244f956d74099851038810fda900a7c
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-zstd-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 62046
+  timestamp: 1736212541958
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-compression-zstd-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 5e75cc15fb8d1935c4874f07291c71c2a2962b7d3d0519da3178de3802708fb8
+  md5: 82578df92049600bdc2c3a7136d53b06
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-zstd-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 60986
+  timestamp: 1736216378178
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-cpp-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 171f00616db086a530a2ba21820b8a315e90071e91fcd5f079dfbfdae3883bb3
+  md5: 302ddf1519dcc0362a221b7d63437dc2
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-shared-queues-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 294803
+  timestamp: 1736211621251
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-cpp-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 44f815e7508c310dcc5830fc6141f28f08a37fab878fe57a7191271d2e5fc447
+  md5: ad24dfda04a1d5b4fca4adbbb3a7da15
+  depends:
+  - python
+  - ros-humble-ament-index-cpp
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-rmw
+  - ros-humble-rmw-implementation
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros-humble-shared-queues-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 287203
+  timestamp: 1736215324288
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 11db7368859bd992f1d2848389f48977194fc6bf769074729e9bc0ad568315af
+  md5: 9a9ca9b20e969908e05470b95c634bb2
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 207965
+  timestamp: 1736209265442
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-interfaces-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 600dc55aa757bfa05c926e747ee9c7207174ff9bf29933cd39c842a6904da412
+  md5: 20609962b98731174a4d4fc24294eec6
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 210822
+  timestamp: 1736211562844
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-py-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 8604a7c44f80cfceb30a3cbe120fe2c4c2fe43c8551a3660b19f87b9afb9b198
+  md5: 64f08939c2c2f6dbf53e94ee1953aa8a
+  depends:
+  - python
+  - ros-humble-pybind11-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosbag2-transport
+  - ros-humble-rpyutils
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 530733
+  timestamp: 1736213719339
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-py-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 11fbfe3af7f844c5b86ea169477da8b1e1656e662681d3b89ae116596e572d4d
+  md5: 68be50cf70a412249da5458d36f83a83
+  depends:
+  - python
+  - ros-humble-pybind11-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-storage
+  - ros-humble-rosbag2-transport
+  - ros-humble-rpyutils
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 494986
+  timestamp: 1736217769645
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 32c8da4b9af76db6025c0c2bae3f905a674bcc15b46f50ee9506d493e54e4df0
+  md5: 5b2ff709a4b8c16f6187616972e2f2ad
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 231148
+  timestamp: 1736210591744
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-storage-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 86387f1a8f15fb5d14124a078cfeb55dc6e6c5418511995d459c18049669ba11
+  md5: 29a21a64a38108c69a06beaee4d27f8a
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 229706
+  timestamp: 1736214461284
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h2c3b307_7.conda
+  sha256: 3f8df70a407dcb4dc40bce2f8a243f5a183794cbe909f0899cd5823772062f36
+  md5: d08821189af864f789a4e4c69777681a
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-storage
+  - ros-humble-sqlite3-vendor
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 125831
+  timestamp: 1736210994133
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-storage-default-plugins-0.15.13-np126py311h65a17ee_5.conda
+  sha256: e2d402a34ff5358bbbde8b75f05110fc4905d9e9a96a8186ae543426c537ab61
+  md5: fd0633a5e2034d0f963779e844e4e439
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-storage
+  - ros-humble-sqlite3-vendor
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 125984
+  timestamp: 1736215073801
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosbag2-transport-0.15.13-np126py311h2c3b307_7.conda
+  sha256: dba49cad737e6d721fa47a4e9fd59d77f2b7c58ee7d0060f9555c04ffbf304b7
+  md5: 67c0aad8a7c42912037119c4cf253999
+  depends:
+  - python
+  - ros-humble-keyboard-handler
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-interfaces
+  - ros-humble-rosbag2-storage
+  - ros-humble-shared-queues-vendor
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 410470
+  timestamp: 1736213583566
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosbag2-transport-0.15.13-np126py311h65a17ee_5.conda
+  sha256: fd88b881910d6cd5444dea3720b98f8ae60615fe6de369ee4e4205fd4de3b970
+  md5: 77e3294237e501c0b1348df1654035a0
+  depends:
+  - python
+  - ros-humble-keyboard-handler
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-compression
+  - ros-humble-rosbag2-cpp
+  - ros-humble-rosbag2-interfaces
+  - ros-humble-rosbag2-storage
+  - ros-humble-shared-queues-vendor
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 404987
+  timestamp: 1736217429124
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosgraph-msgs-1.2.1-np126py311h2c3b307_7.conda
+  sha256: 189117c66097f6319d3b5c4dc6b45b8e0c0275e7ef487b50b587ff4a7ff4cf13
+  md5: 756b632f703ce403a53a11b90c5225d9
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 66220
+  timestamp: 1736209230229
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosgraph-msgs-1.2.1-np126py311h65a17ee_5.conda
+  sha256: b9e0f9ef01e7fd89f0d3b784791f3a4764ca7d505526c9801897476a5462373e
+  md5: 5e5a8a663e370a80fb0e34cfca630dfc
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 69592
+  timestamp: 1736211497563
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-adapter-3.1.6-np126py311h2c3b307_7.conda
+  sha256: b99905f74700d086636bd3e8f84cf06b76194f7a45e34d6168d4f0285396f83a
+  md5: b6f979e1aa1f4f4a9d7ebf804df79bbb
+  depends:
+  - empy
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 62223
+  timestamp: 1736208194197
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-adapter-3.1.6-np126py311h65a17ee_5.conda
+  sha256: 372dd0184534b351f60f18cb7d7a77d06d9d104cfbcd24d50b343a3d669efcaa
+  md5: 88cc0f85aadad805987dda287c0e6bc5
+  depends:
+  - empy
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 62252
+  timestamp: 1736208561269
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cli-3.1.6-np126py311hdfa6bdf_9.conda
+  sha256: 9cb4c78c0ae6f4ee6b34382a53e896c6bdfe2ba1f67b56a91d1283902fd56242
+  md5: 57e3161ca033613c0754a73818974f04
+  depends:
+  - argcomplete
+  - importlib-metadata
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 38582
+  timestamp: 1744199499032
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-cli-3.1.6-np126py311hdeb5fcf_9.conda
+  sha256: 20f174dd04dc716ee9b513ddfee212773bfe771d2073cfa8e1dc8202a721aa83
+  md5: adfcdc7a87a948a77b095830f0e011a2
+  depends:
+  - argcomplete
+  - importlib-metadata
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=13
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 38498
+  timestamp: 1744199780206
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-cmake-3.1.6-np126py311h2c3b307_7.conda
+  sha256: c81c44d584ad1495676305fb795da4265e9b3601bbdfdb1ecf1551db8eb538f5
+  md5: 22d349936b0184cb8fe0897675354a10
+  depends:
+  - empy
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-adapter
+  - ros-humble-rosidl-parser
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 38633
+  timestamp: 1736208538488
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-cmake-3.1.6-np126py311h65a17ee_5.conda
+  sha256: be86d70fdfc9b59e4edaf86985e74b2f22bbcda24d6f4972658a242d3c9907d4
+  md5: deb2be29ab3fc75f86650fe16bd0021c
+  depends:
+  - empy
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-adapter
+  - ros-humble-rosidl-parser
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 38641
+  timestamp: 1736209194690
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-generators-1.2.0-np126py311h2c3b307_7.conda
+  sha256: 757a79d84073db54804062e2ee83cb16e41e244c4281b579dcf1a2b3532bb0e7
+  md5: a310fe4b1d97dd61b2eb16b91c028bb3
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-generator-cpp
+  - ros-humble-rosidl-generator-py
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29839
+  timestamp: 1736209062180
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-default-generators-1.2.0-np126py311h65a17ee_5.conda
+  sha256: 3d7082da188f233a8f067332eef3c4a29066efd15e2fe4c8013fb48e749b6406
+  md5: 11d5703ab3d5110f6a56277342f0e9b6
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-generator-cpp
+  - ros-humble-rosidl-generator-py
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 29770
+  timestamp: 1736211021529
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h2c3b307_7.conda
+  sha256: ea2640211e377c0b880524d4c0bbb2fe6b8f31c1b5c28dba0cc8559ce7e9b6bb
+  md5: 58aabc3c1eb5ff44e274b5c0cff98b23
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-generator-py
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 28848
+  timestamp: 1736209052479
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-default-runtime-1.2.0-np126py311h65a17ee_5.conda
+  sha256: 887cd22ef0e226589e37c42b92bcc78868308a140055868bc95d9fa8da2bb04c
+  md5: 514c583e04463f1de491568f4b6b977c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-generator-py
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 28851
+  timestamp: 1736211005730
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-c-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 09b6a087a006b4c7e9c88f15423f42608ffa1162dac246b0038ae33fe7aba7bd
+  md5: 16e7a9beed934789dbf03a87b737863e
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45261
+  timestamp: 1736208697635
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-c-3.1.6-np126py311h65a17ee_5.conda
+  sha256: 72a33f8b1ca883094a0463a599520684ba891c5c2ec8ae00c3b1c661a16fdef4
+  md5: 12c6f6698f36b92132042424e370fdf7
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45282
+  timestamp: 1736209655330
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 804a896dba771d8afee698816d4fccbd7c99893a3065eeaa4dc2bc9ae36a48dc
+  md5: f6bd1fb10d7e5f4ca7ad0ee095687fae
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 48296
+  timestamp: 1736208736376
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-cpp-3.1.6-np126py311h65a17ee_5.conda
+  sha256: 4e24fc15382b7bacd4edcd91dd48ce14e9f2aa85f62d0049d3bbd2139e108f15
+  md5: 0039174221fb90b15264b86e0344be47
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 48300
+  timestamp: 1736209822003
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-generator-py-0.14.4-np126py311h2c3b307_7.conda
+  sha256: 176b09cbdbcad422eed3a64f54160997f09bc09218f3e426a9b28d7e1fea5d6c
+  md5: d527fad6a5260f831a8b2ccc9ee4ce3b
+  depends:
+  - numpy
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-python-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rpyutils
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 58991
+  timestamp: 1736209027985
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-generator-py-0.14.4-np126py311h65a17ee_5.conda
+  sha256: 11ec8d747a503b2f10997befc72dfbf8ed8a28b36d31d92c50a19c442ae19b22
+  md5: 159a9dec5258b1f044507124cfcc8a37
+  depends:
+  - numpy
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-python-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rpyutils
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 58986
+  timestamp: 1736210872568
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-parser-3.1.6-np126py311h2c3b307_7.conda
+  sha256: f2045ded7e348395ad0a6b98768356836f5c9fdeea38fb66cfdd0b08ae3c9d60
+  md5: ff082e99304c62a808b916b7d1812175
+  depends:
+  - lark-parser
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-adapter
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 58503
+  timestamp: 1736208475571
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-parser-3.1.6-np126py311h65a17ee_5.conda
+  sha256: 35e3452cf958fe3478a32887090379c1e207eb839d7420fe2160018a155270de
+  md5: c0192b3e5d06ae040f1316fefbcf055b
+  depends:
+  - lark-parser
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-adapter
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 58599
+  timestamp: 1736208972338
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 4f21b666450762121f032c0f8c3269d95c7aaea86173e9e9cd686588be9270d2
+  md5: 9a5f67756089c9355dfd72c9a3d11cea
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 46314
+  timestamp: 1736208630684
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-c-3.1.6-np126py311h65a17ee_5.conda
+  sha256: 4162d2a10e2609c3f58bad9562916c0dec39c693c9ef8c87abfd6fd138396274
+  md5: 4ce57a9972a77aa1997b5284c5e96dd9
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 48400
+  timestamp: 1736209450040
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 3d4e2b3cb3f8653038071a9d2c865b5a5d865d457fbb8308cd94f84815e73731
+  md5: b0aaa0da0aae6a06c34b4803b50209c8
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 34058
+  timestamp: 1736208685060
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-cpp-3.1.6-np126py311h65a17ee_5.conda
+  sha256: f3adece2de18af37efcee49391efcfb4b218b6baf2a6b2f85f5cf6d4bf9ed99f
+  md5: 2f08887b999f93bfe365382691a4834a
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 34108
+  timestamp: 1736209637367
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h2c3b307_7.conda
+  sha256: fb296c4c66594ccf8f52fc77a38c5182490c4876f30e9ba178b58acbf8bc1d10
+  md5: 457876038b4f981e1a717e5ea95ffa8c
+  depends:
+  - numpy
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-parser
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 45089
+  timestamp: 1736209598198
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-runtime-py-0.9.3-np126py311h65a17ee_5.conda
+  sha256: 85d9f512bc99d06cd7bc40cc84883ef42ea0b7102f474feadad3181f35286c92
+  md5: 4993688b62108b1431eccd2f5a47edc3
+  depends:
+  - numpy
+  - python
+  - pyyaml
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-parser
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 45026
+  timestamp: 1736212180895
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h2c3b307_7.conda
+  sha256: 91a1352d45770245fe94ed58c15fbd5ed4f20a81c52cdad4873d6d48345d79c7
+  md5: ac116dc81cf89886d20add8207fa4c14
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 47588
+  timestamp: 1736209010857
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-c-2.0.2-np126py311h65a17ee_5.conda
+  sha256: 0340b88a32e6301e875a2d1adb430ae9b9dad66630aa4f5d86405b8332910f71
+  md5: 39343c12058d51ce6afbfd0a41a97cd6
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-typesupport-fastrtps-c
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 47686
+  timestamp: 1736210841122
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h2c3b307_7.conda
+  sha256: 7d525dbd7e3e54d0c19a787f80a1f90eb46fe8bef61c3cff240b2d073fb62623
+  md5: bf18b6b068d1734fb700ecc9153c737a
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 46756
+  timestamp: 1736209021979
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-cpp-2.0.2-np126py311h65a17ee_5.conda
+  sha256: 7131c2da5fb28e950ff0311c846161cd39a32fc463c834d350560fa0589e2140
+  md5: 958ce0970a177c2d2459b1488388a7f6
+  depends:
+  - python
+  - ros-humble-ament-cmake-core
+  - ros-humble-ament-index-python
+  - ros-humble-rcpputils
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-c
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 46934
+  timestamp: 1736210860217
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h2c3b307_7.conda
+  sha256: 0ba946b80619bb404b2ebb8fb3f421a434b1bfeb9d5d88fc71bcb6c567a1a7ab
+  md5: 096294f7cfcc2e22fc0e4c77612121a5
+  depends:
+  - python
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-python
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 46895
+  timestamp: 1736208930591
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-fastrtps-c-2.2.2-np126py311h65a17ee_5.conda
+  sha256: 6c9af1b8d6a30b256efe15040072dac23ef711e2f37ada3ea8e32e4f1ee743da
+  md5: 0b1e73ed8e24a04426d3c31453991dba
+  depends:
+  - python
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-python
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-c
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-fastrtps-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 47297
+  timestamp: 1736210621219
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h2c3b307_7.conda
+  sha256: 4e506897b48cf907ae437420e71e8b80d764c78f0f49ab4574f75f7c12cbd5fd
+  md5: ad63d1859f877850a6c0f2a45058ea7d
+  depends:
+  - python
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-python
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-cpp
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 48940
+  timestamp: 1736208801735
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-fastrtps-cpp-2.2.2-np126py311h65a17ee_5.conda
+  sha256: c95b52a733c58c57d1d6c548705a658115dc23e981775b0271af01a7c7de45d0
+  md5: 086f9c92af9f87b5d9de2bde576a3e74
+  depends:
+  - python
+  - ros-humble-ament-cmake-ros
+  - ros-humble-ament-index-python
+  - ros-humble-fastcdr
+  - ros-humble-fastrtps-cmake-module
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-generator-cpp
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 49248
+  timestamp: 1736210205056
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 61403c3f0bad550b6373e659d35e386b67250a363b4499afe8e56ca8742a763f
+  md5: c766ae1960e035927df3ebafab95e83c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27047
+  timestamp: 1736208166058
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-interface-3.1.6-np126py311h65a17ee_5.conda
+  sha256: abbfb6e2421d4b62dff7c2bdae4f6459b9af888a7112cca2954a8da5e52ee906
+  md5: 901c3795e23aa5066526b6ee3197a21c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27052
+  timestamp: 1736208506582
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h2c3b307_7.conda
+  sha256: 54cf06f2d15fd71d8760c7ccb00ddab4141aee2b9e05642c6ff33f9f109fb913
+  md5: e62862c3d3c3d2e7a79da43c814aa583
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 44587
+  timestamp: 1736208707557
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-c-3.1.6-np126py311h65a17ee_5.conda
+  sha256: ce58a0fecb00e5e8a0a7240e5b30064e256f1841d95d6b4f8855d1e7f9603f34
+  md5: dbba2113d59e14b8ef1907cb4de84bf4
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 45186
+  timestamp: 1736209677348
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h2c3b307_7.conda
+  sha256: e911a28f29af4782227a03c1f2f8c0db3f68cb90604dfb4541faec50a19b5504
+  md5: 6c808a6da6995bc725e3f6bee31267e0
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 44973
+  timestamp: 1736208748719
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rosidl-typesupport-introspection-cpp-3.1.6-np126py311h65a17ee_5.conda
+  sha256: c23285121653170301eda21720b1f46539961ae0e55081f9e89c2775776ad33b
+  md5: dab34ad29af33866fbdef45ff9b453a3
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ament-index-python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-cli
+  - ros-humble-rosidl-cmake
+  - ros-humble-rosidl-parser
+  - ros-humble-rosidl-runtime-c
+  - ros-humble-rosidl-runtime-cpp
+  - ros-humble-rosidl-typesupport-interface
+  - ros-humble-rosidl-typesupport-introspection-c
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 45424
+  timestamp: 1736209842269
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rpyutils-0.2.1-np126py311h2c3b307_7.conda
+  sha256: 577e7562016cf46d8a7f879db09778ee1b132bb9b6c327f8ec01d373dcef1551
+  md5: 5b2f319c93475b695c86db4d43262b5e
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25018
+  timestamp: 1736207198475
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rpyutils-0.2.1-np126py311h65a17ee_5.conda
+  sha256: f9bfecb64521903ac9aa953e5af96e3239afd0fa12cd89447db94857e3be94a8
+  md5: 0fb21ff9b2ddfd73c512b41547bb4d49
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 25083
+  timestamp: 1736207528088
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-action-2.0.1-np126py311h2c3b307_7.conda
+  sha256: f920712b077da56d2907d730b9a4277f9fd3f6fcc37196547ea3e2076c69a4f9
+  md5: c29c04edbd18bcca89a3c78dc87ee72c
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-msg
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 18652
+  timestamp: 1736211997583
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-action-2.0.1-np126py311h65a17ee_5.conda
+  sha256: eff411925935716906414d4cf426dde54358f6db59bb9835c430b701723c7f25
+  md5: f849403fa09f2389930f475c69891b40
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-msg
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 18598
+  timestamp: 1736215671065
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-bag-1.1.5-np126py311h2c3b307_7.conda
+  sha256: 81f204e93ddb63177a2f425a51fabe74e7f5b0d3066da61429dbf8af5c36bad7
+  md5: 5e961c49c389587c94a60f6230f15d28
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-py
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 135079
+  timestamp: 1736214086701
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-bag-1.1.5-np126py311h65a17ee_5.conda
+  sha256: b61e47754ce6c8dac5e55778d17c51dece10b420efe42178ee707f5b83efe245
+  md5: 342757b11055a22f1c62e7742ca17e73
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2-py
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 135034
+  timestamp: 1736218266082
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-bag-plugins-1.1.5-np126py311h2c3b307_7.conda
+  sha256: c08ba9bb7a189dc444e5a8341577639b21569022133f9b491200c732234f9a22
+  md5: 00f3ebe08d32f5f27e80487f4af60850
+  depends:
+  - pillow
+  - pycairo
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2
+  - ros-humble-rqt-bag
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-plot
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 44213
+  timestamp: 1736214862362
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-bag-plugins-1.1.5-np126py311h65a17ee_5.conda
+  sha256: cb21dbe1e8c8058b286e173cf698b28d8dd09e5e85617e18ac2e6fe2a2fa941e
+  md5: 0f3884c89631f55ce29a3cf5a903e98a
+  depends:
+  - pillow
+  - pycairo
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rosbag2
+  - ros-humble-rqt-bag
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-plot
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 44184
+  timestamp: 1736219819284
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-common-plugins-1.2.0-np126py311h2c3b307_7.conda
+  sha256: e88992ddb64ca4b09317ebcd1c5b4f18afa040804f5d4d3829691e608715f57f
+  md5: 63b792571727ac766a253bb0baceb1b2
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-action
+  - ros-humble-rqt-bag
+  - ros-humble-rqt-bag-plugins
+  - ros-humble-rqt-console
+  - ros-humble-rqt-graph
+  - ros-humble-rqt-image-view
+  - ros-humble-rqt-msg
+  - ros-humble-rqt-plot
+  - ros-humble-rqt-publisher
+  - ros-humble-rqt-py-common
+  - ros-humble-rqt-py-console
+  - ros-humble-rqt-reconfigure
+  - ros-humble-rqt-service-caller
+  - ros-humble-rqt-shell
+  - ros-humble-rqt-srv
+  - ros-humble-rqt-topic
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21448
+  timestamp: 1736215244449
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-common-plugins-1.2.0-np126py311h65a17ee_5.conda
+  sha256: beece5a7ba7c6ed97e41326906fbc6115933aa5162e1b0210fbf75220de92f7a
+  md5: c0dd301206649ffe19383d97f1b1e9b7
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-action
+  - ros-humble-rqt-bag
+  - ros-humble-rqt-bag-plugins
+  - ros-humble-rqt-console
+  - ros-humble-rqt-graph
+  - ros-humble-rqt-image-view
+  - ros-humble-rqt-msg
+  - ros-humble-rqt-plot
+  - ros-humble-rqt-publisher
+  - ros-humble-rqt-py-common
+  - ros-humble-rqt-py-console
+  - ros-humble-rqt-reconfigure
+  - ros-humble-rqt-service-caller
+  - ros-humble-rqt-shell
+  - ros-humble-rqt-srv
+  - ros-humble-rqt-topic
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21415
+  timestamp: 1736220570893
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-console-2.0.3-np126py311h2c3b307_7.conda
+  sha256: 58d4b7cdeedeb441997b27bc3b053ce29720c96b51de4160ee5706b836bfc546
+  md5: 8aba9e30cc7235a498c403f541eeadff
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 84887
+  timestamp: 1736210938306
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-console-2.0.3-np126py311h65a17ee_5.conda
+  sha256: 069f95eb625df86344dca9a5e314d5418ce047b83fe8b348340589707cbc2824
+  md5: add138557cfe3edc3474a5fc8eceddd1
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 84860
+  timestamp: 1736214986533
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-graph-1.3.1-np126py311h2c3b307_7.conda
+  sha256: b5b2c931c174763eda50bc4c786fa45e4e2c79ffdf26e4eda9ac590abec6f4a0
+  md5: ca628b258a3881fa88dcb439c3abb1b2
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-dotgraph
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 70041
+  timestamp: 1736211140992
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-graph-1.3.1-np126py311h65a17ee_5.conda
+  sha256: f87578f23b85921eee512c01bd846a1bfb13982a0b610a4dc3ca62d944d558d9
+  md5: 9d4508c7bc26a4acc58e1cf45d39885d
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-dotgraph
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 70014
+  timestamp: 1736215009884
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-1.1.7-np126py311h2c3b307_7.conda
+  sha256: 9cba6e15d20f5083a5bc947784c1ef97a45e48e667e1013cf7e36589e407a7e8
+  md5: 026feaafbbcc5f5ced352be6f66b3e6c
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 126178
+  timestamp: 1736210484512
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-1.1.7-np126py311h65a17ee_5.conda
+  sha256: 599c59cf369de98c164c8f16c8a48e8f02fd76c4fe20195ed2c2cd21b72c78da
+  md5: 7a1a48e3fd28d101997c93d97fb2acca
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 125976
+  timestamp: 1736214175464
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-cpp-1.1.7-np126py311h2c3b307_7.conda
+  sha256: 5fa2b6073c98c319d76b337fb7c496340757ffd0f69bc452b65b81aa7832a209
+  md5: 1e1734bb0ee339696e03e64f59049878
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-cpp
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 179441
+  timestamp: 1736210427860
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-cpp-1.1.7-np126py311h65a17ee_5.conda
+  sha256: 36ca6a8e5c49975228453143e4d7abd57d081507e598df451658f9ac3bdf854c
+  md5: 306c8205fd0fc0a8ad181a63c0d4b0b2
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-cpp
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 181307
+  timestamp: 1736214090863
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-gui-py-1.1.7-np126py311h2c3b307_7.conda
+  sha256: 6fddeb3b1df0befa8e193fe15a412e97a7682fadf186baa9d96bd1207a469629
+  md5: 9e87e404c7b55b61bd13e69f3371704a
+  depends:
+  - python
+  - ros-humble-qt-gui
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 47230
+  timestamp: 1736210606054
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-gui-py-1.1.7-np126py311h65a17ee_5.conda
+  sha256: 967c7a6d406b30c700241628b0db100eb31e725b43adb2d795bced26564c567f
+  md5: e843498e1c14a49108553cb9edcf9e00
+  depends:
+  - python
+  - ros-humble-qt-gui
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 46934
+  timestamp: 1736214512331
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-image-view-1.2.0-np126py311h2c3b307_7.conda
+  sha256: 3636d1e0b156a2ecbe70089d0ad7315d3c7c37cb74288a702f310fcc2157d7d8
+  md5: 2e7e48402ecf3472e57f485c32fe8121
+  depends:
+  - python
+  - ros-humble-cv-bridge
+  - ros-humble-geometry-msgs
+  - ros-humble-image-transport
+  - ros-humble-qt-gui-cpp
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-cpp
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 247605
+  timestamp: 1736211630604
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-image-view-1.2.0-np126py311h65a17ee_5.conda
+  sha256: 4d78edc7ffd1b080cd4ce73192fbf17d8fdd89ef07f44d53a0b8c22177b9f2c5
+  md5: 8197ff0c416d281671c17a2ec5287123
+  depends:
+  - python
+  - ros-humble-cv-bridge
+  - ros-humble-geometry-msgs
+  - ros-humble-image-transport
+  - ros-humble-qt-gui-cpp
+  - ros-humble-rclcpp
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-cpp
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 247044
+  timestamp: 1736215314645
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-msg-1.2.0-np126py311h2c3b307_7.conda
+  sha256: c552cfa03a23c213945a93214686f696cf2e0203e79114537f0d1d50a35d30d4
+  md5: c9dd85dcbf144e2d62d974abe7925856
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-console
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 28148
+  timestamp: 1736211683258
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-msg-1.2.0-np126py311h65a17ee_5.conda
+  sha256: 7cdc349f13a75de54a03965b8679ad17d48e5f87e5874913cb20b98d1a93315e
+  md5: f6aa63474a157504fd5e38286d2d1e46
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-console
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 28080
+  timestamp: 1736215472154
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-plot-1.1.2-np126py311h2c3b307_7.conda
+  sha256: 9736abb80f6c5ed23c8aa14b0db4a3f58a978f6307baaf93c4dbe0b8138b0af4
+  md5: 186ce71e16983faa1ee2510b33368725
+  depends:
+  - catkin_pkg
+  - matplotlib-base
+  - numpy
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 67691
+  timestamp: 1736210938533
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-plot-1.1.2-np126py311h65a17ee_5.conda
+  sha256: 34edb5598aff4f7ebfae23c721d6eaf9db36cee54fc22b1e8e74bdba21bcea88
+  md5: 8fc0a75d61061854862b62bdef7d2d55
+  depends:
+  - catkin_pkg
+  - matplotlib-base
+  - numpy
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 67650
+  timestamp: 1736214988188
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-publisher-1.5.0-np126py311h2c3b307_7.conda
+  sha256: d06b3a29ef836e656c4fd67c5e59afbb82c5064ef9d540dff4e5881f68024617
+  md5: 2eefa97d45d470ed04219d8a0be9005a
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 41434
+  timestamp: 1736211136807
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-publisher-1.5.0-np126py311h65a17ee_5.conda
+  sha256: f3fe0878556cd7e9cceebdcd66a26475823cb067fbbd6ad727bec1811f7ed121
+  md5: ddc760851d20b7dae6ed45d5721cd9e4
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 41410
+  timestamp: 1736215001913
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-py-common-1.1.7-np126py311h2c3b307_7.conda
+  sha256: 3cea8860575a451c307582a90a70cf9a6df708d90c526de3b6010feb6d1c1923
+  md5: 1155735c942b4e65403cc47a27fa6055
+  depends:
+  - python
+  - qt-main
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 84126
+  timestamp: 1736210411641
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-py-common-1.1.7-np126py311h65a17ee_5.conda
+  sha256: 0085c2b8a4696b9f159c6f5e9130a0cf6515aa69b365da22c12a50476296265b
+  md5: 2e29a370022ab1352fdcd75433e268b3
+  depends:
+  - python
+  - qt-main
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 83789
+  timestamp: 1736214059344
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-py-console-1.0.2-np126py311h2c3b307_7.conda
+  sha256: 8c660b2090b23a0404181f191eca096c66a5ac410505c7bbae643cc2503b095a
+  md5: 1482524cd603ce5eaef19815cf4ab64a
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 24439
+  timestamp: 1736211132627
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-py-console-1.0.2-np126py311h65a17ee_5.conda
+  sha256: add9f23832f96a558b820f63ab038c919993cf032edac5ae05350b67d7194e01
+  md5: a5fc4da61433e1a03967ea2f19c8fdc8
+  depends:
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24434
+  timestamp: 1736214987711
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-reconfigure-1.1.2-np126py311h2c3b307_7.conda
+  sha256: 2cdbaf83c61a35f17a228a3c22e97272c3bbe4850fc803b8d441f98d0ed0e3f7
+  md5: 115f4be651655a08db1eff78902dfa87
+  depends:
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-console
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 75484
+  timestamp: 1736211675961
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-reconfigure-1.1.2-np126py311h65a17ee_5.conda
+  sha256: ceddf63f733707dccdb5f8c9e64d47f2ce092abd97695a913165e48c70da7abd
+  md5: b363997a70d963b818d4c7bef4e3e45c
+  depends:
+  - python
+  - pyyaml
+  - ros-humble-ament-index-python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui-py-common
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-console
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 75547
+  timestamp: 1736215382920
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-service-caller-1.0.5-np126py311h2c3b307_7.conda
+  sha256: 8dd77e555f1bdcd7abafeb4b76d25e5751517dedd581538378cb17e6eeb3c3e5
+  md5: b7234516e80e6ade08ec3ddcffd4e7b4
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 31527
+  timestamp: 1736211128251
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-service-caller-1.0.5-np126py311h65a17ee_5.conda
+  sha256: 05b8899cbd3ca5870ff70496c6179c2b6c13c643fa94b4ef2d449d245ebd9c4d
+  md5: 2a4db55356622e5218674a64d0f6652b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 31495
+  timestamp: 1736215036735
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-shell-1.0.2-np126py311h2c3b307_7.conda
+  sha256: d33443ef84ded2d60663efde8b8619bd71fc71596e1b32691df3d5b489407a57
+  md5: 55b8c3d4aeb22675481ab0fb3d83ded0
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-py-common
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 28452
+  timestamp: 1736210941174
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-shell-1.0.2-np126py311h65a17ee_5.conda
+  sha256: 80aa46e4bd54d8da8cc62cae1cd892d7580412748219101c149bce567870896d
+  md5: fc374a724975e7e408ccf4536951a3a0
+  depends:
+  - catkin_pkg
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-qt-gui
+  - ros-humble-qt-gui-py-common
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 28440
+  timestamp: 1736215028876
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-srv-1.0.3-np126py311h2c3b307_7.conda
+  sha256: 9f2252617ad3ed10322043124c95f7029b689968f2149972f82c2b0d58737d4b
+  md5: fe5a754e81d031bd6c7051046c2a5641
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-msg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 18592
+  timestamp: 1736211988237
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-srv-1.0.3-np126py311h65a17ee_5.conda
+  sha256: 38c7a7014f79562c63cfd3c4d28148ff432e811057db36027cf916abbb322a03
+  md5: 9865bc53ea72f787842a60968e10c66b
+  depends:
+  - python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-msg
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 18563
+  timestamp: 1736215865182
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rqt-topic-1.5.0-np126py311h2c3b307_7.conda
+  sha256: 312642e02d5a91fe3aaa8a5584609778f2c30f2ddc87bb1dae72b898cc4deaa3
+  md5: 24e76e59555abce305601d9b221f38a0
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 36997
+  timestamp: 1736211171546
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rqt-topic-1.5.0-np126py311h65a17ee_5.conda
+  sha256: 6f1b898ee25ec601db0e89b8583d56f20646308fba1a22e2fc4ebe67c700b84d
+  md5: f33b046adba896d31293b2a63d6982a6
+  depends:
+  - python
+  - ros-humble-python-qt-binding
+  - ros-humble-ros-workspace
+  - ros-humble-rqt-gui
+  - ros-humble-rqt-gui-py
+  - ros-humble-rqt-py-common
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 37059
+  timestamp: 1736215108183
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h2c3b307_7.conda
+  sha256: d98d4220e5269773db84c25746af5e38095058e85cdcb9d611957402f45f3847
+  md5: ee7773cf356c772693e144aaa1d5c93d
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29372
+  timestamp: 1736208427967
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rti-connext-dds-cmake-module-0.11.3-np126py311h65a17ee_5.conda
+  sha256: 3fc4b84634a382da628a4cdbbdf3011332a5923226e5fbf990d69f66c88d78e6
+  md5: 4f8c7cc957900510711dd65a6f2cf499
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 29413
+  timestamp: 1736208783464
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rttest-0.13.0-np126py311h2c3b307_7.conda
+  sha256: a5babc3ff4d7295f23ba7c11e4328893591e51ea28196e6f8e962edd171cbe80
+  md5: da41b66a6afcccc48afd027a9b717c27
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 51938
+  timestamp: 1736208176734
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rttest-0.13.0-np126py311h65a17ee_5.conda
+  sha256: d5c48ccb6bc2dc39be476183779453055fc3f33630abf90b0dbb9b7a3bc42838
+  md5: 9e47e2052395580d2c3920f05f8ee6cc
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 52779
+  timestamp: 1736208512837
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h2c3b307_7.conda
+  sha256: d958338f5a692eabeacde67daef46aa44c81bec782c55922ad0223c3998e8491
+  md5: 6ab6264160dc97efaaf936f0c5086b01
+  depends:
+  - assimp
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22805
+  timestamp: 1736207942524
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-assimp-vendor-11.2.15-np126py311h65a17ee_5.conda
+  sha256: 62f1c6fb48e074473dd4fe402f29c15c466433c11c2e3372cbcadd50e315953e
+  md5: 094c3aefaf08db898c961367c91d457e
+  depends:
+  - assimp
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - assimp >=5.4.3,<5.4.4.0a0
+  license: BSD-3-Clause
+  size: 22748
+  timestamp: 1736208362254
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-common-11.2.15-np126py311h2c3b307_7.conda
+  sha256: 6aa1c7a40c085cb560e3c691c9a1d9e20c172732043805de98606eef85aa7d3f
+  md5: fa85c669637c948873b6c620f26ef490
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 865497
+  timestamp: 1736211997586
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-common-11.2.15-np126py311h65a17ee_5.conda
+  sha256: bc28aa52384bc13becaf674fbb6de7a405f44ab11e9f0612af25af59f0a34518
+  md5: d8b741a956b9ed11f0d81a4b0c9e4945
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-rcpputils
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf
+  - ros-humble-yaml-cpp-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 855135
+  timestamp: 1736215693159
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-default-plugins-11.2.15-np126py311h2c3b307_7.conda
+  sha256: cbf35da017a8511903729f06c380292d92617d3de7dc8a24fdcc36abd9aa04e0
+  md5: b2fc7d1767d728e5c4f130ab1d5a9c28
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-ignition-math6-vendor
+  - ros-humble-image-transport
+  - ros-humble-interactive-markers
+  - ros-humble-laser-geometry
+  - ros-humble-map-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 2265643
+  timestamp: 1736213020598
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-default-plugins-11.2.15-np126py311h65a17ee_5.conda
+  sha256: 7dca3e434f7ee2ea401b1228d1859c46a8173bda60c628646dcd72289586cdf9
+  md5: 31903cb6d7abc118effc268892822a5d
+  depends:
+  - python
+  - qt-main
+  - ros-humble-geometry-msgs
+  - ros-humble-ignition-math6-vendor
+  - ros-humble-image-transport
+  - ros-humble-interactive-markers
+  - ros-humble-laser-geometry
+  - ros-humble-map-msgs
+  - ros-humble-nav-msgs
+  - ros-humble-pluginlib
+  - ros-humble-rclcpp
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-ogre-vendor
+  - ros-humble-rviz-rendering
+  - ros-humble-tf2
+  - ros-humble-tf2-geometry-msgs
+  - ros-humble-tf2-ros
+  - ros-humble-urdf
+  - ros-humble-visualization-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 2279919
+  timestamp: 1736216975094
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h2c3b307_7.conda
+  sha256: f9786740ee8717af8e9ad1db0d918316dbb6738ce7b383b280124e71ae869700
+  md5: 3486cdfd5dda6d43bfacd203f9cf173b
+  depends:
+  - assimp
+  - freetype
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - zziplib >=0.13.69,<0.14.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: BSD-3-Clause
+  size: 5513885
+  timestamp: 1736207562666
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-ogre-vendor-11.2.15-np126py311h65a17ee_5.conda
+  sha256: ebef36e57f766c6a7046ab58b63c31b42a6c42cbb580f05a9ab5a2a602021c3b
+  md5: 993a13b0b9663c98e68c9bd69326166c
+  depends:
+  - assimp
+  - freetype
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxaw
+  - xorg-libxrandr
+  - xorg-xorgproto
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - libgl >=1.7.0,<2.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - zziplib >=0.13.69,<0.14.0a0
+  - freeimage >=3.18.0,<3.19.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  size: 5402476
+  timestamp: 1736208077180
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz-rendering-11.2.15-np126py311h2c3b307_7.conda
+  sha256: ebcad1222c48f33792266b6c758e72bc3b32c6bd4a4eb534e7a96b04a1978392
+  md5: d53d357fdbbd762a69f72b614790d72e
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-assimp-vendor
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - glew >=2.1.0,<2.2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 902675
+  timestamp: 1736208566702
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz-rendering-11.2.15-np126py311h65a17ee_5.conda
+  sha256: 995bce26e23df4984084d802101863c0a355e044c818dcc9a02acec93f5c2dbf
+  md5: 94029c71e852db03ed23e959768545ab
+  depends:
+  - eigen
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-resource-retriever
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-assimp-vendor
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: BSD-3-Clause
+  size: 894278
+  timestamp: 1736209244385
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-rviz2-11.2.15-np126py311h2c3b307_7.conda
+  sha256: ee3283a41cf43a844dcf6c6fe326e5df23adbf0b5f7321b74d708e5179e02071
+  md5: 24a647930dd99ac9a395b8c8490f92f1
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 59614
+  timestamp: 1736213703075
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-rviz2-11.2.15-np126py311h65a17ee_5.conda
+  sha256: 36037ebb4b8b76fbac18818aa0bcf559c4afa002972613bfcd59509f45c38915
+  md5: 421f7a1c6343a3f6abc137ebb802b911
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rviz-common
+  - ros-humble-rviz-default-plugins
+  - ros-humble-rviz-ogre-vendor
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libxext >=1.3.6,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  license: BSD-3-Clause
+  size: 60673
+  timestamp: 1736217736318
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sdl2-vendor-3.3.0-np126py311h2c3b307_7.conda
+  sha256: 2f310d179571fbf0d0b685b2168e507b5ae174e1cdfc91eb6b65093ad27cfefc
+  md5: 3f13c829bcd754bff0d9b6da49bf863e
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - sdl2
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - sdl2 >=2.30.10,<3.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 25026
+  timestamp: 1736207165091
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sdl2-vendor-3.3.0-np126py311h65a17ee_5.conda
+  sha256: e639ae02d31729ede3e75dbe127ddfca429b1e799f32e5126d18156b3eadab16
+  md5: 1f772b2a640138c1eac4a297bc319b14
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - sdl2
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - sdl2 >=2.30.10,<3.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24786
+  timestamp: 1736207475474
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: d5ee5588dc8f4ecfa831a31c70e0be13728ae19b3c30d8dcc6d5514e781bf317
+  md5: 723fbaf94adae9ec48c6eb6f75b554af
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 446751
+  timestamp: 1736209553492
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 6267a14c8df0bcfdac7c191f441553c643ffbfac91c4d6258f426f5a46dd0f7e
+  md5: 9be998d5e8435efb7d4afb9b7b9b4482
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 455564
+  timestamp: 1736212103609
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sensor-msgs-py-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 4c91002093d9cf7c47f4c399f703bdb4418d104e9936cb7d09937b6c675582cb
+  md5: e6b54b523a0d6ce5a8c013b10e41258d
+  depends:
+  - numpy
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 29787
+  timestamp: 1736209729192
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sensor-msgs-py-4.2.4-np126py311h65a17ee_5.conda
+  sha256: d699a4c523f0a5ab4315f9070c83b4e25668a37b258280dc2195b2d37d845af1
+  md5: 51d20d3f5c9ed45aa7d1f0768f5b0108
+  depends:
+  - numpy
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 29737
+  timestamp: 1736212876895
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shape-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 1625a9f576b641cdd30964a7794735ceb7e3331e3a97564a1d6f138ba501268b
+  md5: cd985400965b9ca9a31d2bae1a06a4ae
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 114007
+  timestamp: 1736209527612
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-shape-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 6d29b061ea527048aa2c40368dc9cce2a12e3a8a11ba0c3f0529c0876b0fdf2e
+  md5: 4e1071b7ee9286dd88eab37c8fc5f5f9
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 117991
+  timestamp: 1736212070135
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-shared-queues-vendor-0.15.13-np126py311h2c3b307_7.conda
+  sha256: f7ebfd5d1b808d07bee8b731613fad977a9a9f3f5faf4a804e48dfbcb827b63b
+  md5: f5e850892627cc24a26ca14e81430423
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 64872
+  timestamp: 1736207175563
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-shared-queues-vendor-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 94ea69a02e83fdd0743aab3a9f3996e9aea2881278f69c08a96777bdcda0ed5e
+  md5: f197974045f615481a28f403275973a8
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 64816
+  timestamp: 1736207500019
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-spdlog-vendor-1.3.1-np126py311h6a008e1_7.conda
+  sha256: c2f08f93c2d6f61109524eed6077e4c2a0d535e0a887de3b05bca2145014c29d
+  md5: 511f6231235fcfbc355a5a6590766599
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - spdlog
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - spdlog >=1.14.1,<1.15.0a0
+  license: BSD-3-Clause
+  size: 24373
+  timestamp: 1736208178457
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-spdlog-vendor-1.3.1-np126py311h1db7994_5.conda
+  sha256: dd2dab35ec8937961f431e18b8d6390361943e28f19172eb6d6eea5e0074d794
+  md5: 8f22df136ec365995d5ead6d4e160055
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - spdlog
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - spdlog >=1.14.1,<1.15.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24389
+  timestamp: 1736208522195
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sqlite3-vendor-0.15.13-np126py311h2c3b307_7.conda
+  sha256: a0c9ac4dc3129e534a1db2d672987920fdf4458961036fdfc192b308f9ff371a
+  md5: 7d6edea29c8d9b572a6717b2bd0e0881
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - sqlite
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - libsqlite >=3.47.2,<4.0a0
+  license: BSD-3-Clause
+  size: 22463
+  timestamp: 1736207164844
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sqlite3-vendor-0.15.13-np126py311h65a17ee_5.conda
+  sha256: bb197103b9eab8b141093a66d618fc2c335f5627e7d252a2005099cd68dacf2c
+  md5: 76e6159fc30da9b3ac454d156c72799e
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - sqlite
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libsqlite >=3.47.2,<4.0a0
+  license: BSD-3-Clause
+  size: 22377
+  timestamp: 1736207480596
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-0.10.5-np126py311h2c3b307_7.conda
+  sha256: 06b3684c099d47646135d349aa525f3ed5b997d27e1d84d0d6778d36bf278e45
+  md5: e85e7bbe01806ea370a094954343b9b9
+  depends:
+  - cryptography
+  - importlib_resources
+  - lxml
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 71932
+  timestamp: 1736211989019
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sros2-0.10.5-np126py311h65a17ee_5.conda
+  sha256: 3ba5a634782a7593fd0791ca73bdcdbe93d60a9c458560e0cf4b5471f94c90ac
+  md5: 0cd1b88f09d5589338eeaeb915699f25
+  depends:
+  - cryptography
+  - importlib_resources
+  - lxml
+  - python
+  - ros-humble-ament-index-python
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 71723
+  timestamp: 1736215665720
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-sros2-cmake-0.10.5-np126py311h2c3b307_7.conda
+  sha256: a82738d225ee8f67b6050e847d2d69808e3e648a90f7beb645c9eedb7677b9b2
+  md5: a4c9d6f957540d75554ecf38bf1c9b6c
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-sros2
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 34894
+  timestamp: 1736212521053
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-sros2-cmake-0.10.5-np126py311h65a17ee_5.conda
+  sha256: 01e30ec7f0f8cbd6bc25d9d6985f8bd7f01612b68fec154a4aee1d3347ad41c2
+  md5: 7c5c466e4d1cedb2905db07e0e050cb0
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-ros2cli
+  - ros-humble-sros2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 34878
+  timestamp: 1736216385529
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-statistics-msgs-1.2.1-np126py311h2c3b307_7.conda
+  sha256: f3473634c3d0ff080603d470533dac5ca61d808dc0f226bd65efd81d2094288d
+  md5: e46f0fc73a7da6bfe440457fe5e42b13
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 98729
+  timestamp: 1736209219341
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-statistics-msgs-1.2.1-np126py311h65a17ee_5.conda
+  sha256: 6d2fb234c802f46cdc1251141c30e859a120c44d7245a31442b16f05c51e8583
+  md5: cf7caf7662c82509281ebb328fc33743
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 102427
+  timestamp: 1736211472922
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: a0ca6df6139c14b7b0d9495661ffa69b9aa6761848c6ff477c05fccd2a8d9b3b
+  md5: 20cc53f864b7f5f1607bc2a63bcfa65d
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 287145
+  timestamp: 1736209174531
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-std-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: bc37be76fa828a889d891b0a650116a6034fb6ad4018b4377f6e4ed589826378
+  md5: 7c1e67af5eba9b79f6abd41db4643d59
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 290647
+  timestamp: 1736211409755
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-std-srvs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 825d91a607a17d01f682620fc9db3b58a9ce756bc74e2ac10b2742017af0e8b5
+  md5: 46a2844ab9a70c17513b557bce3d2a80
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 103766
+  timestamp: 1736209142312
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-std-srvs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 6d76239ee0575436850d8488454b5a5da951f018241068bbad450eede1a1f31b
+  md5: f90a9952cf6fb11cf8751c08d2367c67
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 107321
+  timestamp: 1736211270783
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-stereo-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: abd46f0ec286d815598d99c672511aa7d4c425589006ca743b72f7f6f6f75db2
+  md5: 72f623956cdb15061572a89ee724f6e0
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 74928
+  timestamp: 1736209719860
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-stereo-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 7a0e0c31a5eb1ec13a8e7595343c2b110f039d4afa673fc7424087dcb4d97112
+  md5: de4f8af87a03a1489830cbcda28dafdd
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 78203
+  timestamp: 1736212853542
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tango-icons-vendor-0.1.1-np126py311h2c3b307_7.conda
+  sha256: 6ea059c03356c37c2b8a5aa374aabf08b6bfd30707dfb49201cbb7460f9aa193
+  md5: a5fbaa59e75f79316e95bbf031929bd2
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 24186
+  timestamp: 1736208181778
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tango-icons-vendor-0.1.1-np126py311h65a17ee_5.conda
+  sha256: 73bf219fd98802c23032a3a56cfdb921d9fb13ed4379960e34e00054c8b6d420
+  md5: 4732d88e295de1396a8ac9faf60d6cc2
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 24155
+  timestamp: 1736208539711
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-teleop-twist-joy-2.4.7-np126py311h2c3b307_7.conda
+  sha256: bf240674881f960583dbb391374697ad2be40b1173583b32c95033424e3641a8
+  md5: d5f528fa7c587df50645479c3e645a23
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-joy
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 208745
+  timestamp: 1736211126273
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-teleop-twist-joy-2.4.7-np126py311h65a17ee_5.conda
+  sha256: 7ab39e992051295d28ba96e9998bb125d0c53e381226595e6370852b5ba02b1f
+  md5: 471c7e8ba73872c0d5914bb79abe4d04
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-joy
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 207067
+  timestamp: 1736215000589
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-teleop-twist-keyboard-2.4.0-np126py311h2c3b307_7.conda
+  sha256: 8d4e06658d5b7d0c0d95e88f012a405ea6f87561983bc3ba2f375901b495f4b5
+  md5: 28397c4df0522abdc3a230d91b14a3e6
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21935
+  timestamp: 1736210411371
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-teleop-twist-keyboard-2.4.0-np126py311h65a17ee_5.conda
+  sha256: 8c8312e3ad7c7e872878cde70cbbb6361f8731e72b7e77d9f2844c0d1c66c0aa
+  md5: 414168308bceecb51e743602bfda2556
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21909
+  timestamp: 1736214326008
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 6fe02d77e6da7f4a6b2731ae988de84494e11bd29c20cb91a05615687ef2ba52
+  md5: e9b8816b76d59ee653a52a9efdaa2715
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-console-bridge-vendor
+  - ros-humble-geometry-msgs
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - console_bridge >=1.0.2,<1.1.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 128456
+  timestamp: 1736209604039
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-0.25.10-np126py311h65a17ee_5.conda
+  sha256: d222fe991119c19fe3a6d314ebd0600e3883f369e47b6c24118df10de1be251e
+  md5: 29b02971e3baf66805fc6f6702032510
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-console-bridge-vendor
+  - ros-humble-geometry-msgs
+  - ros-humble-rcutils
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-runtime-cpp
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 125609
+  timestamp: 1736212193559
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-bullet-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 4ae0a06da06cfaf288cfb7d9e400f3ca49a34efdb46a19111bc245361ac0f388
+  md5: 45b2988c7f61043dbb881bdb956171a1
+  depends:
+  - bullet
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 39536
+  timestamp: 1736211673458
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-bullet-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 47ebd4056a267095338b94617095453f2a53705eee628b0e6b18720bdb6aaed6
+  md5: 6fe80a05b8430d5078bcead6fc1afa93
+  depends:
+  - bullet
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 39432
+  timestamp: 1736215448472
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 6505c33db221171103ba8184c74f491e5a8c61aa8f780a2ee5b4598feab8fd98
+  md5: dba8e4e58ca850edcae33dd2a11eda5a
+  depends:
+  - eigen
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 41242
+  timestamp: 1736211956800
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 62e8f4436c5275cbd445b76bb1f78b116a7f62d4288bb39cd2befbb4c7cdb3f1
+  md5: 8459e4a0c331185053a6e2644bfc9feb
+  depends:
+  - eigen
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 41196
+  timestamp: 1736215434240
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h2c3b307_7.conda
+  sha256: db5a4c33c50100339e63ac618fbf3063a6a483c2912a86e92ca5951d22e85e7a
+  md5: 7b695b98df9351330e188be11a8a71f1
+  depends:
+  - eigen
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 38508
+  timestamp: 1736209752538
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-eigen-kdl-0.25.10-np126py311h65a17ee_5.conda
+  sha256: a7353be5e26c37ee841f48b6ec647a28a214f5ea78cb9330e76b6bb59fd58774
+  md5: ea3d375ac6cca2eadca229fb9d2725f5
+  depends:
+  - eigen
+  - python
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 38861
+  timestamp: 1736212723315
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 9b8144f0a34ae074c395f1b3569f081ede62b7ac1a18402b2ece829e219b9c9d
+  md5: c478f0630e6a89a61308365eb6ad5372
+  depends:
+  - numpy
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 53343
+  timestamp: 1736211950116
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-geometry-msgs-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 3a4ff6026aa569e7d7e6ea88494212bf2198efb5755a8595a108f20ad4e64357
+  md5: 61f99a4150f128567d68607b9904e6bf
+  depends:
+  - numpy
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 53364
+  timestamp: 1736215415568
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-kdl-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 0ff26f8c3f00e78b68f1d5b1f2e261d056ec628d99ae35ab5c0206ae6fd69429
+  md5: 32f2383f045d0c5f30b79b3a74c8e2eb
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 40645
+  timestamp: 1736211941805
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-kdl-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 771d90463d11bd52bdbf70eea99a7ce823945afb9a45a6b731080cce380f2f09
+  md5: 05aa976d82d45bee0c5e97a6f73d3a85
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-orocos-kdl-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 40559
+  timestamp: 1736215394700
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-msgs-0.25.10-np126py311h2c3b307_7.conda
+  sha256: a2776c3b977fc8675bbff86b3f34ae17b834b2c83564a77fd69cfc6d2714b332
+  md5: 0dc644a401df0c9a082f8329c1263d0e
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 169623
+  timestamp: 1736209498161
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-msgs-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 0a3177b3301fb558a5aa5012dc5346896c1ae94d6d95d1769b28084c7499fc97
+  md5: f4eb537e3bef07eedf4126c7e1d766ed
+  depends:
+  - python
+  - ros-humble-action-msgs
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 172222
+  timestamp: 1736212030698
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-py-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 578471eb8eb5f27c9d34ab5997534161b85d196a70fa58e428ea54c35023e8c5
+  md5: fa58cb44e231cfa8aa7769e0452b8634
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rpyutils
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 56388
+  timestamp: 1736210416687
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-py-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 2c83d35e0813e2774d8c7e09414a137db74dac2ebcb2aa6119566a637aed2951
+  md5: cb386d6294ab652e3e43fa3934db5672
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-rpyutils
+  - ros-humble-tf2
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 54564
+  timestamp: 1736214067861
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 4c18b4d53bbdf042f4371926a9ef0eff621903dc0c7e25043e87e4d5a6ab8a60
+  md5: 8d313bcb9449e2957fdbf556505db01c
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 453920
+  timestamp: 1736211133887
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-ros-0.25.10-np126py311h65a17ee_5.conda
+  sha256: d917f1f51e318458874afb4a282af9eda2f7680d8540e15a9e1f991437d9d2fd
+  md5: 95b653b50130ae079788c8e6b3a18d04
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-message-filters
+  - ros-humble-rcl-interfaces
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-rclcpp-components
+  - ros-humble-ros-workspace
+  - ros-humble-tf2
+  - ros-humble-tf2-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 459108
+  timestamp: 1736215006021
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-ros-py-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 9df298e6371ce208b40d72daa90cab8b86a5620d29977b3d9acded105b5606b9
+  md5: 68a671871fdfb526f021115745acbc03
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 44200
+  timestamp: 1736210596445
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-ros-py-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 184c58f7b54f1bfdb3a9383c359a9dcdd0c62fff02d21c8ab7f7379acb5785a6
+  md5: c7c60cc21bb26ba3f5202f8dede01443
+  depends:
+  - python
+  - ros-humble-geometry-msgs
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 44116
+  timestamp: 1736214474414
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h2c3b307_7.conda
+  sha256: de38a0dfe18d1b10d5d72398447c0b20f5a66b5c7ae836f8095a111b55b7e661
+  md5: 8ec7342886b74cb140f16b92d0d047f5
+  depends:
+  - eigen
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 38360
+  timestamp: 1736211645916
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-sensor-msgs-0.25.10-np126py311h65a17ee_5.conda
+  sha256: 54fe60f56323b8b2da7488c2371395f292ec5fd0b6c6b4767d455a7de14b0c90
+  md5: 1761148ee0b852ef51da45c5211f0708
+  depends:
+  - eigen
+  - python
+  - ros-humble-eigen3-cmake-module
+  - ros-humble-ros-workspace
+  - ros-humble-sensor-msgs
+  - ros-humble-tf2
+  - ros-humble-tf2-ros
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 38382
+  timestamp: 1736215373361
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tf2-tools-0.25.10-np126py311h2c3b307_7.conda
+  sha256: 7270b4ef9fd242e0fb3c3f3970f271a3789efb62277719339626b74ec5c045b6
+  md5: a00a7703b8519ca887eaa7fdb28b657e
+  depends:
+  - graphviz
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 20886
+  timestamp: 1736211126812
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tf2-tools-0.25.10-np126py311h65a17ee_5.conda
+  sha256: eccdc6ffe7a715dbaad50aede4b16c9f2420b4991cc496fe009bae0f7e7fb0c4
+  md5: 4e158dd1bdfe6de31c57742b3045947f
+  depends:
+  - graphviz
+  - python
+  - pyyaml
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-tf2-msgs
+  - ros-humble-tf2-py
+  - ros-humble-tf2-ros-py
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 20858
+  timestamp: 1736215002359
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml-vendor-0.8.3-np126py311h2c3b307_7.conda
+  sha256: 76313f87e43fc876d9dbf339ae5f2437b7e1485051de42442fd32cabce90f357
+  md5: 314342ffe6366e117e03c233c4fc7467
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - tinyxml
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 22231
+  timestamp: 1736207356735
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tinyxml-vendor-0.8.3-np126py311h65a17ee_5.conda
+  sha256: 81803c3e02a03b0025f9206eccfc24b1903ed73924af846f7ba941a4acad20c5
+  md5: 0e6c59c5a019327cc255eed62bfb2c2b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - tinyxml
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 22168
+  timestamp: 1736207487543
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h2c3b307_7.conda
+  sha256: 82cddc9517bd4660bea7a2471125f9eb9ede985a89f55f3b8f99f537a81c904c
+  md5: 29e0571ab48c0924ab11ec97cd82bb6d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml2
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22399
+  timestamp: 1736207361444
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tinyxml2-vendor-0.7.6-np126py311h65a17ee_5.conda
+  sha256: b4f645d7466eaa66085426f88a3b2357fc8df419f1157475950320d0659268a9
+  md5: 410aee817734400846605979ddbf98b8
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml2
+  - libstdcxx >=14
+  - libgcc >=14
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 22322
+  timestamp: 1736207497458
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tlsf-0.7.0-np126py311h2c3b307_7.conda
+  sha256: 1d79d89d279af9a1938ce0684297663d6f4b2609ce179bb9feaadb13e6e0090a
+  md5: d825319646b727d554a11a04918255f8
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 30892
+  timestamp: 1736208193069
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tlsf-0.7.0-np126py311h65a17ee_5.conda
+  sha256: 4fb621f5b0eb72c9f03e514b9d8cf793bbc4856f29e74f945c30aa064b55bde1
+  md5: 0950638f3c7fae32c56b0a28687e02f5
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 30685
+  timestamp: 1736208562720
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tlsf-cpp-0.13.0-np126py311h2c3b307_7.conda
+  sha256: d0f93de55a988af03d891aefe1111930d91458136000f273e9ec77c51aba9606
+  md5: d2fc361a560dc173678e8b64ce51a027
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros-humble-tlsf
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 183322
+  timestamp: 1736210420210
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tlsf-cpp-0.13.0-np126py311h65a17ee_5.conda
+  sha256: 851d86fcd23f1079976034d6eb039521154a440981b6c5a10d691f59af39ee65
+  md5: 50d297a0221fe447b819b2bff305d7bf
+  depends:
+  - python
+  - ros-humble-ament-cmake
+  - ros-humble-rclcpp
+  - ros-humble-rmw
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros-humble-tlsf
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 184545
+  timestamp: 1736214063150
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-topic-monitor-0.20.5-np126py311h2c3b307_7.conda
+  sha256: 96f423ca71bd9c6583a39b9a86ff298b9b6d0565b244e5bf1c29b9325f8a10b1
+  md5: d9f7f616f8a657af826ca50cf54993fa
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 46530
+  timestamp: 1736210679519
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-topic-monitor-0.20.5-np126py311h65a17ee_5.conda
+  sha256: 46e3fe925a48d6a46467af737c18141213b65e0a66f7b8e827f9301550044338
+  md5: 7e16b1a2db8c836659f79bb275a8bdf2
+  depends:
+  - python
+  - ros-humble-launch
+  - ros-humble-launch-ros
+  - ros-humble-rclpy
+  - ros-humble-ros-workspace
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 46400
+  timestamp: 1736214605881
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-tracetools-4.1.1-np126py311h2c3b307_7.conda
+  sha256: c4cdb72d6d393c8f687632e4038f4936c8b05737607e74dc1f9d5b4d719d5a9e
+  md5: b7b04a244845adb1c027beba4612b05b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 38270
+  timestamp: 1736208482873
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-tracetools-4.1.1-np126py311h65a17ee_5.conda
+  sha256: bea5c2b0c48f0398e379fdde4b1bef5a679252fe2723b7d373970a114b354e8a
+  md5: 4621fae6a418f001b643f7d9d916f7a6
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 40250
+  timestamp: 1736208993861
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-trajectory-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 2c45c08a48609c91cf7ddf99a07d444532df62cfdd3e0d27f2ced33759e300bb
+  md5: b732868f9f69f638fe1018db2b89b066
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 132443
+  timestamp: 1736209541107
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-trajectory-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: 455d3fcce95aedca97608f3005ecba75654005722264e6de1a3708098b8469c3
+  md5: 56269cebe701b7cb547cb302f34c55d9
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 135277
+  timestamp: 1736212097692
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-turtlesim-1.4.2-np126py311h2c3b307_7.conda
+  sha256: 915e777a69a1a2bfb92b354d2112c07c03e3614209dcd743928473bb1cca2ff4
+  md5: 20c6c962faddbcbee3cb2234e709b19f
+  depends:
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-geometry-msgs
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros-humble-std-srvs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - libopengl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 710769
+  timestamp: 1736210629645
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-turtlesim-1.4.2-np126py311h65a17ee_5.conda
+  sha256: f15e0fc9062c7951b891ebf2000aa8bc30a3207a7e51d9c0841c13ec12314c6b
+  md5: 7beff45bff7a80eb4717da7489b30436
+  depends:
+  - python
+  - qt-main
+  - ros-humble-ament-index-cpp
+  - ros-humble-geometry-msgs
+  - ros-humble-rclcpp
+  - ros-humble-rclcpp-action
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-std-msgs
+  - ros-humble-std-srvs
+  - ros2-distro-mutex 0.6.* humble_*
+  - xorg-libx11
+  - xorg-libxext
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - numpy >=1.26.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 727353
+  timestamp: 1736214508243
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-uncrustify-vendor-2.0.2-np126py311h2c3b307_7.conda
+  sha256: 34f4089b2862eaa690b67dea3f39bda0a2a56cd15158de3a90a519d2cf5cdd86
+  md5: 2ab7fbb64863708e0a4108350511f315
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - uncrustify
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - uncrustify >=0.74.0,<0.75.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 21306
+  timestamp: 1736207178839
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-uncrustify-vendor-2.0.2-np126py311h65a17ee_5.conda
+  sha256: 0eadac0a27ab00e1257e59b6eca26d928d6764b0d64edbaa430e53d7d56533da
+  md5: 1b128705a1565b83a50554c3604bb26d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - uncrustify
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - uncrustify >=0.74.0,<0.75.0a0
+  license: BSD-3-Clause
+  size: 21233
+  timestamp: 1736207490693
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h2c3b307_7.conda
+  sha256: c4fcd02dac0e3ce9bfc960fe574f8f55b910e08f265b1cf1d09a319a45f0bf9d
+  md5: cf71ad54ee011fb5b538f98880ac3e67
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 68439
+  timestamp: 1736209086378
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-unique-identifier-msgs-2.2.1-np126py311h65a17ee_5.conda
+  sha256: 52282912b0ff639f0e8e3940ae4bbced9be7dc3759a8ae47d46b147489986105
+  md5: 16190a00db45c3583fa72ab42aac5075
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 71632
+  timestamp: 1736211153570
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-2.6.1-np126py311h2c3b307_7.conda
+  sha256: 49934ffe1fb16408ba55c109486252780f7d73b080d0e2f552031fc92eb9cfaf
+  md5: 1d3db4c06fe6b149e20da0261752908f
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf-parser-plugin
+  - ros-humble-urdfdom
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 152471
+  timestamp: 1736208812739
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdf-2.6.1-np126py311h65a17ee_5.conda
+  sha256: b204b9c340dad3392fe25f4793603380152af13ce7cb89826131e02c8b737425
+  md5: 8d92480319770b05b412c2abc08fc058
+  depends:
+  - python
+  - ros-humble-pluginlib
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml2-vendor
+  - ros-humble-urdf-parser-plugin
+  - ros-humble-urdfdom
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 153177
+  timestamp: 1736210225956
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h2c3b307_7.conda
+  sha256: e4be64214684a114693b8bcf51bff186fdf19c0d185edb81e070f767eb018259
+  md5: 3f1f001b8b81197ce54328b9e0e90954
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 29653
+  timestamp: 1736208492539
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdf-parser-plugin-2.6.1-np126py311h65a17ee_5.conda
+  sha256: 4dcbec02efbf7c8bcd2a99d181cb1be2a019ca0fbfab1d1ebfae2af44d040dda
+  md5: 2db12eebb40bf681b09cb922218d7eeb
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 29656
+  timestamp: 1736209015796
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-3.0.2-np126py311h2c3b307_7.conda
+  sha256: 73f02cf524bd8d8418767239ba7bda3af9fbec34c25f161ca15d189f69b1fdb7
+  md5: 508705cafe28eceaab9ee37edadfebbd
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml-vendor
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - python_abi 3.11.* *_cp311
+  - tinyxml
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 124473
+  timestamp: 1736208544154
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdfdom-3.0.2-np126py311h65a17ee_5.conda
+  sha256: 93856de4234d85d2e87870f86efd5ce06249693a78f631d35ce4f0f1914cc8d8
+  md5: 1ff3ea0a2acc7cf0b3087043cf55a9a0
+  depends:
+  - console_bridge
+  - python
+  - ros-humble-console-bridge-vendor
+  - ros-humble-ros-workspace
+  - ros-humble-tinyxml-vendor
+  - ros-humble-urdfdom-headers
+  - ros2-distro-mutex 0.6.* humble_*
+  - tinyxml
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - console_bridge >=1.0.2,<1.1.0a0
+  - numpy >=1.26.4,<2.0a0
+  - tinyxml
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 132210
+  timestamp: 1736209206456
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-urdfdom-headers-1.0.6-np126py311h2c3b307_7.conda
+  sha256: bd3b5c1d7a38ed4c057d1b35f0e3f6743d550c267925db41a87aa744ab2efcf5
+  md5: 12d4112736de3561059974c62179203b
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 27125
+  timestamp: 1736205378985
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-urdfdom-headers-1.0.6-np126py311h65a17ee_5.conda
+  sha256: 456accb9142ca99ae5fea0cc7a07895e2e516a965160733c1f550fae73674489
+  md5: d780efd15145af3e8812719dc08e5b8f
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 27089
+  timestamp: 1736205812095
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-visualization-msgs-4.2.4-np126py311h2c3b307_7.conda
+  sha256: 20ba46f0268464d8794a13ff9e10105144711cf78dd23ba15560ccc8fab5edfe
+  md5: fcfa4a23cad646713b7bbc18fb7e26ba
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 298958
+  timestamp: 1736209690733
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-visualization-msgs-4.2.4-np126py311h65a17ee_5.conda
+  sha256: ebd0615fd46fa6c37521f874659dead5e651c5e7f037fd48803b20e5143dedc6
+  md5: 02574189a36b4ffb89c6787f7ff5bc71
+  depends:
+  - python
+  - ros-humble-builtin-interfaces
+  - ros-humble-geometry-msgs
+  - ros-humble-ros-workspace
+  - ros-humble-rosidl-default-runtime
+  - ros-humble-sensor-msgs
+  - ros-humble-std-msgs
+  - ros2-distro-mutex 0.6.* humble_*
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  license: BSD-3-Clause
+  size: 303281
+  timestamp: 1736212800836
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h2c3b307_7.conda
+  sha256: 09ba8fc666229f747e2fd99c8109ced58a71041b62d7437176794dac18888c25
+  md5: c8e76afd8d24248addd6ea9fffdb3e0e
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml-cpp
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - numpy >=1.26.4,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  license: BSD-3-Clause
+  size: 21823
+  timestamp: 1736207365699
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-yaml-cpp-vendor-8.0.2-np126py311h65a17ee_5.conda
+  sha256: 05b48def85a1ae0188bf850ce7781ec3807c3feb9b00d3b25d44f6329704395f
+  md5: a6d0ad2089ff76bad8356b65c74cce9d
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - yaml-cpp
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.4,<2.0a0
+  - yaml-cpp >=0.8.0,<0.9.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  license: BSD-3-Clause
+  size: 21762
+  timestamp: 1736207511130
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros-humble-zstd-vendor-0.15.13-np126py311h2c3b307_7.conda
+  sha256: da2d53b05255ca1dccb9352714e17c0587b9cb78b0465b288f7dd7e72696c516
+  md5: bd744a023f60b32cd93d921bb894ec08
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - zstd
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - numpy >=1.26.4,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21920
+  timestamp: 1736207370934
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros-humble-zstd-vendor-0.15.13-np126py311h65a17ee_5.conda
+  sha256: 28c43337942e67419cea0eb853286bb7b8d4278eb10891ea573fd5b586fe5fee
+  md5: 06f980083f971168bc50e087e0ac93fb
+  depends:
+  - python
+  - ros-humble-ros-workspace
+  - ros2-distro-mutex 0.6.* humble_*
+  - zstd
+  - libstdcxx >=14
+  - libgcc >=14
+  - zstd >=1.5.6,<1.6.0a0
+  - numpy >=1.26.4,<2.0a0
+  - ros2-distro-mutex >=0.6.0,<0.7.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  size: 21847
+  timestamp: 1736207521296
+- conda: https://conda.anaconda.org/robostack-humble/linux-64/ros2-distro-mutex-0.6.0-humble_0.conda
+  sha256: 7634989268abeecfd928b94bce3722b8fcb8ef8cc94f55636153036dd7d93bed
+  md5: 5df036dfe2bb64af00f112c9e1cb7bcd
+  constrains:
+  - libboost 1.86.*
+  - libboost-devel 1.86.*
+  - pcl 1.14.1.*
+  - gazebo 11.*
+  - libprotobuf 5.28.2.*
+  license: BSD-3-Clause
+  size: 2423
+  timestamp: 1736205283672
+- conda: https://conda.anaconda.org/robostack-humble/linux-aarch64/ros2-distro-mutex-0.6.0-humble_0.conda
+  sha256: 05d5b1dc6fb8a1e714f0c4a9859ab1698ff6a8e36a920387a929381a372c0a6b
+  md5: 472f93cd76fd2c733a49410c530354bd
+  constrains:
+  - libboost 1.86.*
+  - libboost-devel 1.86.*
+  - pcl 1.14.1.*
+  - gazebo 11.*
+  - libprotobuf 5.28.2.*
+  license: BSD-3-Clause
+  size: 2423
+  timestamp: 1736205478491
+- conda: https://conda.anaconda.org/conda-forge/noarch/rosdistro-1.0.1-pyhd8ed1ab_0.conda
+  sha256: bff3b2fe7afe35125669ffcb7d6153db78070a753e1e4ac3b3d8d198eb6d6982
+  md5: b7ed380a9088b543e06a4f73985ed03a
+  depends:
+  - catkin_pkg
+  - python >=3.9
+  - pyyaml
+  - rospkg
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 47691
+  timestamp: 1747826651335
+- conda: https://conda.anaconda.org/conda-forge/noarch/rospkg-1.6.0-pyhd8ed1ab_0.conda
+  sha256: 236e8b53b0fab599d63f346b0e84fbe9bd8d160e0dd1e591e39f23ff6924941e
+  md5: 80daa4ba1f1944b8ac1f90a66fc9ef27
+  depends:
+  - catkin_pkg
+  - distro
+  - python >=3.9
+  - pyyaml
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 31293
+  timestamp: 1737835793379
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.54-h3f2d84a_0.conda
+  sha256: 7cd82ca1d1989de6ac28e72ba0bfaae1c055278f931b0c7ef51bb1abba3ddd2f
+  md5: 91f8537d64c4d52cbbb2910e8bd61bd2
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - sdl3 >=3.2.10,<4.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  size: 587053
+  timestamp: 1745799881584
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.32.54-h5ad3122_0.conda
+  sha256: d83c13fc35ed447d186150d32b8bc48bdd73a047280ba6e06f151d4cce52639d
+  md5: 6b38021cb802b4e5bede7fe38c547883
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - libegl >=1.7.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - sdl3 >=3.2.10,<4.0a0
+  license: Zlib
+  size: 597383
+  timestamp: 1745799910298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.2.16-he3e324a_0.conda
+  sha256: 7fe5ff84801d1ad0713efbb1a9c39c3c4245ccee5586bd62fc4604d0f23ce0df
+  md5: c3ab38fdbcf36625620c9a4df786320a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - dbus >=1.16.2,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libxkbcommon >=1.10.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  - libudev1 >=257.6
+  - libegl >=1.7.0,<2.0a0
+  - liburing >=2.10,<2.11.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - libunwind >=1.6.2,<1.7.0a0
+  license: Zlib
+  size: 1941645
+  timestamp: 1748911618893
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl3-3.2.16-h7e2c5d6_0.conda
+  sha256: 782c6ac4f96e2b75cf55afdd223ffd043fc459a5a7c7b460c4077764733d5bd9
+  md5: 37fbfe4c4baa10eca13823b535ec5d1a
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - libxkbcommon >=1.10.0,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libunwind >=1.6.2,<1.7.0a0
+  - libusb >=1.0.29,<2.0a0
+  - libudev1 >=257.6
+  - wayland >=1.23.1,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - dbus >=1.16.2,<2.0a0
+  - liburing >=2.10,<2.11.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libdrm >=2.4.124,<2.5.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: Zlib
+  size: 1899812
+  timestamp: 1748911660322
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+  sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
+  md5: 4de79c071274a53dcaf2a8c749d1499e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 748788
+  timestamp: 1748804951958
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py311hfdbb021_0.conda
+  sha256: 1eae0d5f0152714cdabb5cd3d480080e164b3fb5f7bd8208df7925d8e173d36b
+  md5: 78e5e37d25d5ab01fb5e91b8653b8f6d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  - tomli
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 686578
+  timestamp: 1745411313879
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sip-6.12.0-py311h2e0833b_0.conda
+  sha256: 88b24520448a09da8738e1481b9ce5e7548ec8a20cad286d07a3c03e12a49d41
+  md5: 6f46181bfeb1226b529705bad2d0e65b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - packaging
+  - ply
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  - tomli
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 695769
+  timestamp: 1748976817966
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 16385
+  timestamp: 1733381032766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
+  sha256: ec91e86eeb2c6bbf09d51351b851e945185d70661d2ada67204c9a6419d282d3
+  md5: 3b3e64af585eadfb52bb90b553db5edf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 42739
+  timestamp: 1733501881851
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-hd4fb6f5_1.conda
+  sha256: c4a07ae5def8d55128f25a567a296ef9d7bf99a3bc79d46bd5160c076a5f50af
+  md5: 2fcc6cd1e5550deb509073fd2e6693e1
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43032
+  timestamp: 1733501964775
+- conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
+  sha256: 17007a4cfbc564dc3e7310dcbe4932c6ecb21593d4fec3c68610720f19e73fb2
+  md5: 755cf22df8693aa0d1aec1c123fa5863
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 73009
+  timestamp: 1747749529809
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
+  sha256: 0c604fe3f78ddb2b612841722bd9b5db24d0484e30ced89fac78c0a3f524dfd6
+  md5: 909188c8979846bac8e586908cf1ca6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fmt >=11.0.1,<11.1a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 195665
+  timestamp: 1722238295031
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/spdlog-1.14.1-h9d9cc24_1.conda
+  sha256: bcec80ee6145e30c1aaec1e6b4632318c9165b1fc08def6a090982de16bf299d
+  md5: 771630cc938de801e261c3a069d22a68
+  depends:
+  - fmt >=11.0.1,<11.1a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 194216
+  timestamp: 1722238356907
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.2-hb7a22d2_0.conda
+  sha256: 47f8c0350a9c6060d63494edc9abbf115125b0b98f5f6cfdac4e5f471d7d74ba
+  md5: efe16ab2f63053af723e070f3f9bac4c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libsqlite 3.50.2 h6cd9bfd_0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 165182
+  timestamp: 1751135632342
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.50.2-h1b15455_0.conda
+  sha256: b77310bf0ba6a0597261d3f938e5d95ae21cea90e0c10a09a9ddfb65cfa4fcb0
+  md5: 9562528dbd85fbd1fb9415b87c7ad47d
+  depends:
+  - libgcc >=13
+  - libsqlite 3.50.2 he2a92bd_0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  size: 169972
+  timestamp: 1751135661829
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+  sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
+  md5: 355898d24394b2af353eb96358db9fdd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2746291
+  timestamp: 1730246036363
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
+  sha256: 2fad2496a21d198ea72f5dabfdace2fae0ced5cc3ea243922cb372fcf4c18222
+  md5: efb60b536bbf64772929b57f6b30298b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1796731
+  timestamp: 1730246027014
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
+  sha256: 69ab5804bdd2e8e493d5709eebff382a72fab3e9af6adf93a237ccf8f7dbd624
+  md5: 460eba7851277ec1fd80a1a24080787a
+  depends:
+  - kernel-headers_linux-64 3.10.0 he073ed8_18
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 15166921
+  timestamp: 1735290488259
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
+  sha256: 1e478bfd87c296829e62f0cae37e591568c2dcfc90ee6228c285bb1c7130b915
+  md5: 5af44a8494602d062a4c6f019bcb6116
+  depends:
+  - kernel-headers_linux-aarch64 4.18.0 h05a177a_18
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
+  license_family: GPL
+  size: 15739604
+  timestamp: 1735290496248
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.1.0-h4ce085d_0.conda
+  sha256: b2819dd77faee0ea1f14774b603db33da44c14f7662982d4da4bbe76ac8a8976
+  md5: f0afd0c7509f6c1b8d77ee64d7ba64b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 179639
+  timestamp: 1743578685131
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.1.0-hf6e3e71_0.conda
+  sha256: 3dea624f5495c4cfe1bd5a35d67f5995c3a4cde42024ec57855ddab502e1ea3c
+  md5: 0d08f8f53a51b2dfbcda8ebe3be28103
+  depends:
+  - libgcc >=13
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 144738
+  timestamp: 1743581521035
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+  sha256: d9e3c192c535c06ec139ada7bcd1f12313ebd377208fc8149348e8534229f39e
+  md5: 39dd0757ee71ccd5b120440dce126c37
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  size: 56535
+  timestamp: 1611562094388
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+  sha256: d7f66bd0ddfbe1b8f2638678d962140e8ab8a63d779b9366247e1f7daabeb575
+  md5: 454eb4b31a1f4313c72ef7f536cae5d9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  license: Zlib
+  size: 56283
+  timestamp: 1611562275383
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h3f2d84a_2.conda
+  sha256: 997162d7585a3453cf5563ca563d645b512699b3ddf64bb28aaa6f3d771e3cb4
+  md5: 4feae0cd8a72cd1ef72b7528730946e5
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=13
+  - libgcc >=13
+  license: Zlib
+  size: 130740
+  timestamp: 1742462199793
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h5ad3122_2.conda
+  sha256: d416af4266f613bc1f4dedf38bc3bc3eb5b7784452133188abf6de93d6ba1a94
+  md5: 64be65c7bc62c827ed74282b1400c217
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libgcc >=13
+  license: Zlib
+  size: 132954
+  timestamp: 1742462534997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+  sha256: 46e10488e9254092c655257c18fcec0a9864043bdfbe935a9fbf4fb2028b8514
+  md5: 2562c9bfd1de3f9c590f0fe53858d85c
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3342845
+  timestamp: 1748393219221
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
+  sha256: 34f3a83384ac3ac30aefd1309e69498d8a4aa0bf2d1f21c645f79b180e378938
+  md5: b0dd904de08b7db706167240bf37b164
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 22132
+  timestamp: 1734091907682
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19167
+  timestamp: 1733256819729
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
+  sha256: 8561db52f278c5716b436da6d4ee5521712a49e8f3c70fcae5350f5ebb4be41c
+  md5: 2adcd9bb86f656d3d43bf84af59a1faf
+  depends:
+  - python >=3.9
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 50978
+  timestamp: 1748959427551
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+  sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
+  md5: 4222072737ccff51314b5ece9c7d6f5a
+  license: LicenseRef-Public-Domain
+  size: 122968
+  timestamp: 1742727099393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uncrustify-0.74.0-h27087fc_0.tar.bz2
+  sha256: d6f3cf66b1eca558a5e68f5517b37c7be3b931527687ba6c2cb107d4f3e2efb2
+  md5: 98f0d60caa3da9382a26c55d9ebd240d
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 746941
+  timestamp: 1647071114396
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uncrustify-0.74.0-h4de3ea5_0.tar.bz2
+  sha256: aad30c5036e307e254efee60fdd0b124a4b7a838a9c464a89e7a4578bebdefe7
+  md5: c79178747b2addb6788a9566c75bb37d
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-only
+  license_family: GPL
+  size: 717491
+  timestamp: 1647072423707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
+  sha256: e786fb0925515fffc83e393d2a0e2814eaf9be8a434f1982b399841a2c07980b
+  md5: 51a12678b609f5794985fda8372b1a49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 405017
+  timestamp: 1736692662280
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-16.0.0-py311ha879c10_0.conda
+  sha256: 5c03da86510e4ec0c3817a8746b4040fffcfdb1a522dfcc84a07c9a5ede0a1b9
+  md5: b0f8e22b8d108706bcac2eed58eac317
+  depends:
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 405328
+  timestamp: 1736692678670
+- conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.6-h005c6e1_0.conda
+  sha256: ec540ff477cd6d209b98f9b201e9c440908ea3a8b62e9e02dd12fcb60fff6d08
+  md5: 9464e297fa2bf08030c65a54342b48c3
+  license: BSL-1.0
+  size: 13447
+  timestamp: 1730672182037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/utfcpp-4.0.6-h01cc221_0.conda
+  sha256: c8b19a825ec19387181be2c2a63a649f408b6c77fe5f01389565011755150c86
+  md5: 4bc420dcc08be7b850d1d6e9e32e0a0e
+  license: BSL-1.0
+  size: 13427
+  timestamp: 1730672219363
+- conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-9.3.1-qt_py311h71fb23e_215.conda
+  sha256: fb6b2ca7eeed916881e1974b21542de3b73cf7076e5e9b1c54b38702a988ce39
+  md5: 55c7e25733e05610d690bcae54d4f8f2
+  depends:
+  - vtk-base 9.3.1 qt_py311h75c0fa1_215
+  - vtk-io-ffmpeg 9.3.1 qt_py311h71fb23e_215
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24135
+  timestamp: 1739143738631
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-9.3.1-qt_py311h502ffb0_213.conda
+  sha256: 4e8bbffd1046416a3814b5a94deeb7373a231fe22ee13870f915958f6c72060a
+  md5: 5213a57652f415f14600a707981844c1
+  depends:
+  - vtk-base 9.3.1 qt_py311h71e73b3_213
+  - vtk-io-ffmpeg 9.3.1 qt_py311h502ffb0_213
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23356
+  timestamp: 1736180423622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.3.1-qt_py311h75c0fa1_215.conda
+  sha256: 7748d0cbc2a81bdd746e4e9046722cf1ce685be04482254949b8c4e2d4a73688
+  md5: 2993a769b2c78223c491cab828ac15ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - double-conversion >=3.3.0,<3.4.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gl2ps >=1.4.2,<1.4.3.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglvnd >=1.7.0,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libpng >=1.6.46,<1.7.0a0
+  - libsqlite >=3.48.0,<4.0a0
+  - libstdcxx >=13
+  - libtheora >=1.1.1,<1.2.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - loguru
+  - lz4-c >=1.10.0,<1.11.0a0
+  - nlohmann_json
+  - numpy
+  - proj >=9.5.1,<9.6.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - qt6-main >=6.8.2,<6.9.0a0
+  - tbb >=2021.13.0
+  - tk >=8.6.13,<8.7.0a0
+  - utfcpp
+  - wslink
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  constrains:
+  - paraview ==9999999999
+  - libboost_headers
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 46486205
+  timestamp: 1739143551211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-base-9.3.1-qt_py311h71e73b3_213.conda
+  sha256: ff578ca800aa2f6b5740392e10c1cd44f31b8c704eca3d7aa7137fb81a0cc420
+  md5: 870229f627884a24edb4eca55e779b22
+  depends:
+  - double-conversion >=3.3.0,<3.4.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gl2ps >=1.4.2,<1.4.3.0a0
+  - glew >=2.1.0,<2.2.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libglvnd >=1.7.0,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblzma >=5.6.3,<6.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.47.2,<4.0a0
+  - libstdcxx >=13
+  - libtheora >=1.1.1,<1.2.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - loguru
+  - lz4-c >=1.10.0,<1.11.0a0
+  - nlohmann_json
+  - numpy
+  - proj >=9.5.1,<9.6.0a0
+  - pugixml >=1.14,<1.15.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - qt6-main >=6.7.3,<6.9.0a0
+  - tbb >=2021.13.0
+  - tk >=8.6.13,<8.7.0a0
+  - utfcpp
+  - wslink
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxau >=1.0.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  constrains:
+  - paraview ==9999999999
+  - libboost_headers
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 43045121
+  timestamp: 1736180223827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-io-ffmpeg-9.3.1-qt_py311h71fb23e_215.conda
+  sha256: 39184de974d7cce69fd4c9b925fd864a1a46ca41e3a112b508aab2aa1ba5abbf
+  md5: 656c6e14ef32af76c9c573cea93969dc
+  depends:
+  - ffmpeg >=7.1.0,<8.0a0
+  - vtk-base 9.3.1 qt_py311h75c0fa1_215
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82237
+  timestamp: 1739143737794
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.3.1-qt_py311h502ffb0_213.conda
+  sha256: 0a9562ce699aaabfb489e08a24533d1eefb3bb9a0436b6e3164a69feb5460d43
+  md5: 83e71efdc8afcd4b9730ca849bbf71c8
+  depends:
+  - ffmpeg >=7.1.0,<8.0a0
+  - vtk-base 9.3.1 qt_py311h71e73b3_213
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 81139
+  timestamp: 1736180423072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_1.conda
+  sha256: 73d809ec8056c2f08e077f9d779d7f4e4c2b625881cad6af303c33dc1562ea01
+  md5: a37843723437ba75f42c9270ffe800b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 321099
+  timestamp: 1745806602179
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_1.conda
+  sha256: b4f36d5acd06945d0fe4da61ec469fc0f0948458172d13013dabb30854f1ccd3
+  md5: 229b00f81a229af79547a7e4776ccf6e
+  depends:
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 324694
+  timestamp: 1745806658759
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.45-hd8ed1ab_0.conda
+  sha256: 37b0e03a943c048e143f624c51b329778f36923052092fd938827f8c19a4941d
+  md5: 6db9be3b67190229479780eeeee1b35b
+  license: MIT
+  license_family: MIT
+  size: 138011
+  timestamp: 1749836220507
+- conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.3.4-pyhd8ed1ab_0.conda
+  sha256: a3d344dbca9b8c94b84f7428d031e4376397f495bfe8a169adacb8ae87440777
+  md5: 9748c4ed9bb4784914bedf2efcc0ac1f
+  depends:
+  - aiohttp <4
+  - msgpack-python >=1,<2
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 35753
+  timestamp: 1747717971323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
+  md5: 6c99772d483f566d59e25037fea2c4b1
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 897548
+  timestamp: 1660323080555
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+  sha256: b48f150db8c052c197691c9d76f59e252d3a7f01de123753d51ebf2eed1cf057
+  md5: 0efaf807a0b5844ce5f605bd9b668281
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1000661
+  timestamp: 1660324722559
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 3357188
+  timestamp: 1646609687141
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+  sha256: cb2227f2441499900bdc0168eb423d7b2056c8fd5a3541df4e2d05509a88c668
+  md5: 786853760099c74a1d4f0da98dd67aea
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 1018181
+  timestamp: 1646610147365
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+  md5: fdc27cb255a7a2cc73b7919a968b48f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 20772
+  timestamp: 1750436796633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
+  sha256: d874906e236a5edc9309d479599bf2de4d8adca0f23c355b76759d5fb3c4bef8
+  md5: 159ffec8f7fab775669a538f0b29373a
+  depends:
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 21517
+  timestamp: 1750437961489
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+  sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
+  md5: eb44b3b6deb1cab08d72cb61686fe64c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.13
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 20296
+  timestamp: 1726125844850
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-cursor-0.1.5-h86ecc28_0.conda
+  sha256: c2608dc625c7aacffff938813f985c5f21c6d8a4da3280d57b5287ba1b27ec21
+  md5: d6bb2038d26fa118d5cbc2761116f3e5
+  depends:
+  - libgcc >=13
+  - libxcb >=1.13
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  size: 21123
+  timestamp: 1726125922919
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 24551
+  timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
+  md5: b82e5c78dbbfa931980e8bfe83bce913
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  size: 24910
+  timestamp: 1718880504308
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 14314
+  timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
+  md5: 57ca8564599ddf8b633c4ea6afee6f3a
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 14343
+  timestamp: 1718846624153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 16978
+  timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
+  md5: 7beeda4223c5484ef72d89fb66b7e8c1
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 18139
+  timestamp: 1718849914457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 51689
+  timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
+  md5: f14dcda6894722e421da2b7dcffb0b78
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  size: 50772
+  timestamp: 1718845072660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.45-hb9d3cd8_0.conda
+  sha256: a5d4af601f71805ec67403406e147c48d6bad7aaeae92b0622b7e2396842d3fe
+  md5: 397a013c2dc5145a70737871aaa87e98
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 392406
+  timestamp: 1749375847832
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.45-h86ecc28_0.conda
+  sha256: 730ff2f6fbfecce94db54bbf3f1ae0ce79c54b6abc089f8a65a041525228d454
+  md5: 01251d1503a253e39be4fa9bcf447d63
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 392754
+  timestamp: 1749375869926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  md5: fb901ff28063514abb6046c9ec2c4a45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 58628
+  timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+  sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+  md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 60433
+  timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+  md5: 1c74ff8c35dcadf952a16f752ca5aa49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 27590
+  timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+  sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+  md5: 2d1409c50882819cb1af2de82e2b7208
+  depends:
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 28701
+  timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
+  sha256: 51909270b1a6c5474ed3978628b341b4d4472cd22610e5f22b506855a5e20f67
+  md5: db038ce880f100acc74dba10302b5630
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 835896
+  timestamp: 1741901112627
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.12-hca56bd8_0.conda
+  sha256: 452977d8ad96f04ec668ba74f46e70a53e00f99c0e0307956aeca75894c8131d
+  md5: 3df132f0048b9639bc091ef22937c111
+  depends:
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 864850
+  timestamp: 1741901264068
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
+  sha256: ed10c9283974d311855ae08a16dfd7e56241fac632aec3b92e3cfe73cff31038
+  md5: f6ebe2cb3f82ba6c057dde5d9debe4f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 14780
+  timestamp: 1734229004433
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-h86ecc28_0.conda
+  sha256: 7829a0019b99ba462aece7592d2d7f42e12d12ccd3b9614e529de6ddba453685
+  md5: d5397424399a66d33c80b1f2345a36a6
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 15873
+  timestamp: 1734230458294
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxaw-1.0.16-hb9d3cd8_0.conda
+  sha256: 105ff923b60286188978d7b3aa159b555e2baf4c736801f62602d4127159f06d
+  md5: 7c0a9bf62d573409d12ad14b362a96e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  - xorg-libxpm >=3.5.17,<4.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 307032
+  timestamp: 1727870272246
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxaw-1.0.16-h86ecc28_0.conda
+  sha256: 6b113e620781efc14c6ae8d6a65436f9c7e5231e2dd9384b7de71abb920eeee2
+  md5: 4c4a80cc042d707a61dfe75f541e0d23
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxmu >=1.2.1,<2.0a0
+  - xorg-libxpm >=3.5.17,<4.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 331138
+  timestamp: 1727870334121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.6-hb9d3cd8_2.conda
+  sha256: 753f73e990c33366a91fd42cc17a3d19bb9444b9ca5ff983605fa9e953baf57f
+  md5: d3c295b50f092ab525ffe3c2aa4b7413
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13603
+  timestamp: 1727884600744
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcomposite-0.4.6-h86ecc28_2.conda
+  sha256: 0cb82160412adb6d83f03cf50e807a8e944682d556b2215992a6fbe9ced18bc0
+  md5: 86051eee0766c3542be24844a9c3cf36
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13982
+  timestamp: 1727884626338
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxcursor-1.2.3-h86ecc28_0.conda
+  sha256: c5d3692520762322a9598e7448492309f5ee9d8f3aff72d787cf06e77c42507f
+  md5: f2054759c2203d12d0007005e1f1296d
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 34596
+  timestamp: 1730908388714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13217
+  timestamp: 1727891438799
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
+  md5: d5773c4e4d64428d7ddaa01f6f845dc7
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13794
+  timestamp: 1727891406431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
+  md5: 8035c64cb77ed555e3f150b7b3972480
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 19901
+  timestamp: 1727794976192
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
+  md5: 25a5a7b797fe6e084e04ffe2db02fc62
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 20615
+  timestamp: 1727796660574
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+  sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
+  md5: febbab7d15033c913d53c7a2c102309d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50060
+  timestamp: 1727752228921
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
+  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 50746
+  timestamp: 1727754268156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+  sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
+  md5: 4bdb303603e9821baf5fe5fdff1dc8f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 19575
+  timestamp: 1727794961233
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
+  md5: 78f8715c002cc66991d7c11e3cf66039
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 20289
+  timestamp: 1727796500830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
+  md5: eeee3bdb31c6acde2b81ad1b8c287087
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 48197
+  timestamp: 1727801059062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+  sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
+  md5: 5e2eb9bf77394fc2e5918beefec9f9ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 13891
+  timestamp: 1727908521531
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+  sha256: 5f84f820397db504e187754665d48d385e0a2a49f07ffc2372c7f42fa36dd972
+  md5: a7b99f104e14b99ca773d2fe2d195585
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 14388
+  timestamp: 1727908606602
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxmu-1.2.1-hb9d3cd8_1.conda
+  sha256: 467cba5106e628068487dcbc2ba2dbd6a434e75d752eaf0895086e9fe65e6a8d
+  md5: f35a9a2da717ade815ffa70c0e8bdfbd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 89078
+  timestamp: 1727965853556
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxmu-1.2.1-h57736b2_1.conda
+  sha256: 18a1d4591976d2266adf6951ce6edaadf9f4994408c6d15e0b5d8f41b8154671
+  md5: 198cb350a783849b5683dbaac3ca96df
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 92167
+  timestamp: 1727965913339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxpm-3.5.17-hb9d3cd8_1.conda
+  sha256: 8ce7ae21dcbbb759c6fb9e5ad2a2f2f4e54172adf160ea59e11712598edbb75c
+  md5: f35bec7fface97f67f44ca952fc740b7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 64764
+  timestamp: 1727801210327
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxpm-3.5.17-h86ecc28_1.conda
+  sha256: ce7d4a2c075e594b034ee8080271dd7244b0e10a54f1aeb42a5d5eca2f3a950d
+  md5: b9fbc43bcc6bd9aa22f0aa4b81cac173
+  depends:
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxt >=1.3.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 69584
+  timestamp: 1727801259630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+  sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
+  md5: 2de7f99d6581a4a7adbff607b5c278ca
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 29599
+  timestamp: 1727794874300
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+  sha256: b2588a2b101d1b0a4e852532c8b9c92c59ef584fc762dd700567bdbf8cd00650
+  md5: dd3e74283a082381aa3860312e3c721e
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 30197
+  timestamp: 1727794957221
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  md5: 96d57aba173e878a2089d5638016dc5e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 33005
+  timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+  sha256: ffd77ee860c9635a28cfda46163dcfe9224dc6248c62404c544ae6b564a0be1f
+  md5: ae2c2dd0e2d38d249887727db2af960e
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 33649
+  timestamp: 1734229123157
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+  sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
+  md5: 303f7a0e9e0cd7d250bb6b952cecda90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 14412
+  timestamp: 1727899730073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxshmfence-1.3.3-hb9d3cd8_0.conda
+  sha256: c0830fe9fa78d609cd9021f797307e7e0715ef5122be3f784765dad1b4d8a193
+  md5: 9a809ce9f65460195777f2f2116bae02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 12302
+  timestamp: 1734168591429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxshmfence-1.3.3-h86ecc28_0.conda
+  sha256: 9057e4a85a093d733719228d44aa09924e879ee769a9bb79ef7035cd0f260c8e
+  md5: c11f706a5072c34a559848f27d6c28c3
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 13805
+  timestamp: 1734168631514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+  sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+  md5: a9e4852c8e0b68ee783e7240030b696f
+  depends:
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 384752
+  timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 32808
+  timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxtst-1.2.5-h57736b2_3.conda
+  sha256: 6eaffce5a34fc0a16a21ddeaefb597e792a263b1b0c387c1ce46b0a967d558e1
+  md5: c05698071b5c8e0da82a282085845860
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 33786
+  timestamp: 1727964907993
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.6-hb9d3cd8_0.conda
+  sha256: 8a4e2ee642f884e6b78c20c0892b85dd9b2a6e64a6044e903297e616be6ca35b
+  md5: 5efa5fa6243a622445fdfd72aee15efa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 17819
+  timestamp: 1734214575628
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.6-h86ecc28_0.conda
+  sha256: 012f0d1fd9fb1d949e0dccc0b28d9dd5a8895a1f3e2a7edc1fa2e1b33fc0f233
+  md5: d745faa2d7c15092652e40a22bb261ed
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 18185
+  timestamp: 1734214652726
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
+  md5: 7c21106b851ec72c037b162c216d8f05
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 565425
+  timestamp: 1726846388217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
+  md5: 91cef7867bf2b47f614597b59705ff56
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 566948
+  timestamp: 1726847598167
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
+  sha256: 802725371682ea06053971db5b4fb7fbbcaee9cb1804ec688f55e51d74660617
+  md5: 68eae977d7d1196d32b636a026dc015d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  - liblzma-devel 5.8.1 hb9d3cd8_2
+  - xz-gpl-tools 5.8.1 hbcc6ac9_2
+  - xz-tools 5.8.1 hb9d3cd8_2
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23987
+  timestamp: 1749230104359
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.1-h2dbfc1b_2.conda
+  sha256: f8b2b55a672402bf6c870529c20a1a006f102e1604682d83c30a57ec9f3de55a
+  md5: 176b552740e8836d92c4935244d6756b
+  depends:
+  - libgcc >=13
+  - liblzma 5.8.1 h86ecc28_2
+  - liblzma-devel 5.8.1 h86ecc28_2
+  - xz-gpl-tools 5.8.1 h2dbfc1b_2
+  - xz-tools 5.8.1 h86ecc28_2
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 23963
+  timestamp: 1749232914469
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
+  sha256: 840838dca829ec53f1160f3fca6dbfc43f2388b85f15d3e867e69109b168b87b
+  md5: bf627c16aa26231720af037a2709ab09
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33911
+  timestamp: 1749230090353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.1-h2dbfc1b_2.conda
+  sha256: 1e328310210b507064d6b5916c66ce49d4e1ba2fba5a710a5371e6e0432a4731
+  md5: 0d5f95b450e75655b5e76ae626197383
+  depends:
+  - libgcc >=13
+  - liblzma 5.8.1 h86ecc28_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33948
+  timestamp: 1749232746339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
+  sha256: 58034f3fca491075c14e61568ad8b25de00cb3ae479de3e69be6d7ee5d3ace28
+  md5: 1bad2995c8f1c8075c6c331bf96e46fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 96433
+  timestamp: 1749230076687
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.1-h86ecc28_2.conda
+  sha256: b8653678a9954303b948a4be79092101b926087c41fc06bd26573876bb6d3e2a
+  md5: 04a5f1734c23daf8c7fe59045f755efb
+  depends:
+  - libgcc >=13
+  - liblzma 5.8.1 h86ecc28_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 101611
+  timestamp: 1749232578309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+  sha256: 8bc601d6dbe249eba44b3c456765265cd8f42ef1e778f8df9b0c9c88b8558d7e
+  md5: b853307650cb226731f653aa623936a4
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  size: 92927
+  timestamp: 1641347626613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
+  sha256: 4b0b713a4308864a59d5f0b66ac61b7960151c8022511cdc914c0c0458375eca
+  md5: 92b90f5f7a322e74468bb4909c7354b5
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 223526
+  timestamp: 1745307989800
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-cpp-0.8.0-h5ad3122_0.conda
+  sha256: e146d83cdcf92506ab709c6e10acabd18a3394a23e6334a322c57e5d1d6d9f26
+  md5: b9e5a9da5729019c4f216cf0d386a70c
+  depends:
+  - libstdcxx >=13
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 213281
+  timestamp: 1745308220432
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py311h2dc5d0c_0.conda
+  sha256: 9b6cce2794e836a43679d733b8bdbafeed45ff534c338b84d439ed55cd7b2170
+  md5: 18c288aa6aae90e2fd8d1cf01d655e4f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - idna >=2.0
+  - libgcc >=13
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 151355
+  timestamp: 1749555157521
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yarl-1.20.1-py311h58d527c_0.conda
+  sha256: 6a6d6b85422e8bf9e1b0ca09e414ae57e4aafe8797e990883f1d4b18c6fb6ff6
+  md5: deff36ad6ad1800ab8aaaa9e587b7c37
+  depends:
+  - idna >=2.0
+  - libgcc >=13
+  - multidict >=4.0
+  - propcache >=0.2.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 151456
+  timestamp: 1749555022085
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
+  sha256: 7560d21e1b021fd40b65bfb72f67945a3fcb83d78ad7ccf37b8b3165ec3b68ad
+  md5: df5e78d904988eb55042c0c97446079f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 22963
+  timestamp: 1749421737203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
+  md5: bc230abb5d21b63ff4799b0e75204783
+  depends:
+  - libgcc >=13
+  - libzlib 1.3.1 h86ecc28_2
+  license: Zlib
+  license_family: Other
+  size: 95582
+  timestamp: 1727963203597
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567578
+  timestamp: 1742433379869
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-hbcf94c1_2.conda
+  sha256: 0812e7b45f087cfdd288690ada718ce5e13e8263312e03b643dd7aa50d08b51b
+  md5: 5be90c5a3e4b43c53e38f50a85e11527
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 551176
+  timestamp: 1742433378347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zziplib-0.13.69-he45264a_2.conda
+  sha256: a7c3ba25f384c7eb30c4f4c2d390f62714e0b4946d315aa852749f927b4b03ff
+  md5: 6d2d107e0fb8bc381acd4e9c68dbeae7
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later OR MPL-1.1
+  size: 106915
+  timestamp: 1719242059793
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zziplib-0.13.69-h650d8d0_2.conda
+  sha256: 9e3764d1fb2b509bc43ebb059a5bb77ba11af56bb78a5960e1ba8a21aa1939a6
+  md5: 133bf2541e6bc4f7bb7c4e0546776138
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.0-or-later OR MPL-1.1
+  size: 115725
+  timestamp: 1719242037690

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,50 @@
+# pixi build instructions (works on linux-64 and linux-aarch64 (arm))
+#
+# Install pixi via wget-command:
+# - wget -qO- https://pixi.sh/install.sh | sh
+# - Now restart your terminal or shell to make pixi effective.
+#
+# Build the software (exclude webots simulato)
+# - pixi run build
+#
+
+[workspace]
+authors = ["Jurge vanEijck <jurge.van.eijck@gmail.com>"]
+channels = ["robostack-humble", "conda-forge"]
+name = "MRA-components"
+platforms = ["linux-64", "linux-aarch64"]
+version = "0.1.0"
+
+[activation]
+scripts = ["install/setup.sh"]
+
+[tasks]
+refresh = "rm -rf ./log; rm -rf ./build; rm -rf ./install"
+build = "colcon build --symlink-install"
+test = "colcon test --ctest-args tests"
+test_results = "colcon test-result --all --verbose"
+# set RMW_IMPLEMENTATION="rmw_cyclonedds_cpp" : solve 1 second init delay by switching to CycloneDDS
+#sim = { cmd= "ros2 launch simulation launch.py num_robots_team_A:=5 num_robots_team_B:=5 timeout:=10", env = { RMW_IMPLEMENTATION= "rmw_cyclonedds_cpp"} }
+
+
+[dependencies]
+colcon-common-extensions = ">=0.3.0,<0.4"
+compilers = ">=1.9.0,<2"
+make = ">=4.4.1,<5"
+ninja = ">=1.13.0,<2"
+pkg-config = ">=0.29.2,<0.30"
+ros-humble-ament-cmake-auto = ">=1.3.11,<2"
+ros-humble-ament-cmake-clang-format = ">=0.12.11,<0.13.0"
+ros-humble-ament-lint-auto = ">=0.12.11,<0.13"
+ros-humble-builtin-interfaces = ">=1.2.1, <1.3"
+ros-humble-desktop = ">=0.10.0,<0.11"
+ros-humble-geometry-msgs = ">=4.2.4,<4.3.0"
+ros-humble-rosidl-default-generators = ">=1.2.0, <1.3.0"
+ros-humble-rosidl-default-runtime = ">=1.2.0, <1.3.0"
+ros-humble-rclcpp = ">=16.0.11,<17"
+ros-humble-pluginlib = ">=5.1.0,<6"
+ros-humble-rmw-cyclonedds-cpp = ">=1.3.4,<2"
+ros-humble-ament-cmake-python = ">=1.3.11,<2"
+cmake = "3.26.*"
+
+


### PR DESCRIPTION
-  Added support for building with pixi. 
    - The pixi.lock ensure that the build is reproducable.  (More details can be found at: https://pixi.sh/latest/workspace/lockfile/#what-is-a-lock-file )
- Set minimum version in CMakeLists.txt to 3.16 (cmake 3.16 is released in 2019) - to avoid warnings
